### PR TITLE
Refactors the documentation to allow more documentation without loosi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,8 @@ now = $(shell date +"%Y-%m-%d")
 integration-tests:
 	docker-compose run --rm -e DJANGO_POSTGRES_USER=postgres -e DJANGO_POSTGRES_PASSWORD=qwerty service python manage.py test --settings=surf.settings.tests --nomigrations $(filter)
 
-backup-db:
-	docker exec -i $(shell docker ps -qf label=nl.surfcatalog.db) pg_dump -h localhost -U postgres -c edushare > edushare.${now}.postgres.sql
-
-import-db:
-	cat $(backup) | docker exec -i $(shell docker ps -qf label=nl.surfcatalog.db) psql -h localhost -U postgres edushare
-
 start-services:
 	docker-compose -f docker-compose.yml up
 
 stop-services:
 	docker-compose -f docker-compose.yml down
-
-run-service-container:
-	# Starts the main service container outside of docker-compose orchestration
-	# This is useful for allowing debuggers to work while running UWSGI
-	docker-compose run --service-ports service
-
-run-django:
-	while true; do python service/manage.py runserver; sleep 2; done

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 Search Portal
 =============
 
-A search service for finding open access higher education learning materials.
+Search service for finding open access higher education learning materials.
 
-The repo consists of a frontend and a backend. The frontend is called ``portal`` and is a Vue SPA. 
+The repo consists of a frontend, a backend and a background task component.
+The frontend is called ``portal`` and is a Vue SPA.
 The backend is named ``service``, which is mostly a REST API, but also serves the frontend SPA and Django admin pages.
+Background tasks are handled by a Celery Django app named ``harvester``,
+but there is also an admin available for that part.
 
 
 Prerequisites
@@ -23,9 +26,9 @@ To stay close to the production environment it works well to run the project in 
 External services like the database run in containers so it's always necessary to use Docker.
 
 
-#### Backend
+#### General setup
 
-To install the backend you'll need to first setup a local environment on a host machine with:
+To install the basic environment and tooling you'll need to first setup a local environment on a host machine with:
 
 ```bash
 python3 -m venv venv
@@ -42,37 +45,16 @@ to the ``.env`` file or add ``127.0.0.1 postgres`` to your hosts file, in order 
 Similarly for the Elastic cluster you need to add ``POL_ELASTIC_SEARCH_HOST=127.0.0.1`` to the ``.env`` file
 or add ``127.0.0.1 elasticsearch`` to your hosts file.
 
-
-##### Django setup
-
-After the initial Python/machine setup you can further setup your Django database with the following commands:
+To finish the general setup you can run this command to build all containers:
 
 ```bash
 docker-compose -f docker-compose.yml up --build
-source activate.sh  # perhaps redundant, already activated above
-export DJANGO_POSTGRES_USER=postgres  # the root user who will own all tables
-cd service
-python manage.py migrate
-cd ..
 ```
-
-This should have setup your database for the most part.
-Unfortunately due to historic reasons there is a lot of configuration going on in the database.
-So it's wise to get a production dump and import it to your system.
-Please ask somebody access to the S3 database dumps bucket. Place the latest dump inside ``postgres/dumps``
-and then run:
-
-```bash
-make import-db backup=postgres/dumps/<dump-file-name>.sql
-```
-
-To finish the Django setup you can create a superuser for yourself using the ``createsuperuser`` command.
 
 
 ##### Elastic Search setup
 
-Similarly to how you can load data into your Postgres database
-it's possible to load data into the Elastic Search cluster.
+It's possible to load data into the Elastic Search cluster from a few commands
 In order to do that you first need to setup with:
 
 ```bash
@@ -94,16 +76,6 @@ Alternatively you can set the
 This allows to connect your local setup to a remote development or testing cluster.
 
 
-#### Frontend
-
-Installation of the frontend is a lot more straightforward than the backend:
-
-```bash
-cd portal
-npm install
-```
-
-
 #### Resetting your database
 
 Sometimes you want to start fresh.
@@ -120,7 +92,7 @@ And then follow the steps above to recreate the database and populate it.
 Getting started
 ---------------
 
-The local setup is made in such a way that you can run the project inside and outside of containers.
+The local setup is made in such a way that you can run the components of the project inside and outside of containers.
 External services like the database always run in containers.
 Make sure that you're using a terminal that you won't be using for anything else, 
 as any containers will print their output to the terminal.
@@ -144,80 +116,20 @@ make start-services
 make stop-services
 ```
 
-After that you can start your local Django development server in the ``service`` directory.
-
-Or you can choose to run the entire project in containers with:
+After that you can follow the guides to [start the service](service/README.md),
+[work with the frontend](portal/README.md) or start the harvester.
+Alternatively you can choose to run all components of the project in containers with:
 
 ```bash
 docker-compose up
 docker-compose down
 ```
 
-Either way the Django admin, API and a database admin tool become available under:
+
+#### Available apps
+
+Either way the database admin tool become available under:
 
 ```bash
-http://localhost:8000/admin/
-http://localhost:8000/api/v1/
-http://localhost:8081/  # for database administration
-```
-
-Last but not least you'll have to start the Vue frontend with:
-
-```bash
-cd portal
-npm run serve
-```
-
-Which makes the frontend available through:
-
-```bash
-http://localhost:8080/
-```
-
-
-#### Logging in locally
-
-On the servers the login works through SURFConext.
-It's a bit of a hassle to make that work locally.
-So we've opted for a way to work around SURFConext when logging in during development.
-
-Simply login to the Django admin.
-Once logged in clicking the frontend login button.
-This will fetch an API token on Vue servers in development mode and "log you in".
-From there on out there is no difference between the remote and local login.
-
-
-#### Migrate locally
-
-Database tables are owned by the root database user called "postgres".
-This is a different user than the application database user.
-and that causes problems when you try to migrate,
-because the application user is not allowed to alter or create anything.
-
-To apply migrations locally you'll need to switch the connection to the root user.
-You can do so by setting an environment variable before running the migration:
-
-```bash
-export DJANGO_POSTGRES_USER=postgres
-cd service
-python manage.py migrate
-```
-
-
-Tests
------
-
-The test suite is rather limited at the moment. There's not real tests at all for the portal.
-However there are some tests for the integration with
-the Edurep search engine and our own Elastic Search powered engine.
-These engines are what makes the portal tick in the end
-and currently you can switch between the two engines with a deploy.
-The adapter that connects to these search engines is fully tested.
-These tests also assert that the two engines return more or less the same content.
-This is to keep the ability to switch engines when needed.
-
-Run these integration tests with the following command:
-
-```bash
-make integration-tests
+http://localhost:8081/
 ```

--- a/portal/README.md
+++ b/portal/README.md
@@ -1,0 +1,47 @@
+Search Portal Single Page Application
+=====================================
+
+A frontend build in Vue that provides a search bar, filters and viewing results.
+As well as a way for users to organise themselves in communities.
+
+
+Installation
+------------
+
+Installation of the frontend is a lot more straightforward than the other components.
+From the ``portal`` directory run:
+
+```bash
+npm install
+```
+
+
+Getting started
+---------------
+
+You can run the frontend with its own server.
+
+```bash
+npm run serve
+```
+
+
+#### Available apps
+
+If you run the frontend development server it becomes available under:
+
+```bash
+http://localhost:8080/
+```
+
+
+#### Logging in locally
+
+On the servers the login works through SURFConext.
+It's a bit of a hassle to make that work locally.
+So we've opted for a way to work around SURFConext when logging in during development.
+
+Simply login to the Django admin of the ``service``.
+Once logged in clicking the frontend login button.
+This will fetch an API token in development mode and "log you in".
+From there on out there is no difference between the remote and local login.

--- a/service/Makefile
+++ b/service/Makefile
@@ -1,0 +1,14 @@
+backup-db:
+	docker exec -i $(shell docker ps -qf label=nl.surfcatalog.db) pg_dump -h localhost -U postgres -c edushare > edushare.${now}.postgres.sql
+
+import-db:
+	cat $(backup) | docker exec -i $(shell docker ps -qf label=nl.surfcatalog.db) psql -h localhost -U postgres edushare
+
+run-service-container:
+	# Starts the main service container outside of docker-compose orchestration
+	# This is useful for allowing debuggers to work while running UWSGI
+	cd ..
+	docker-compose run --service-ports service
+
+run-django:
+	while true; do python manage.py runserver; sleep 2; done

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,103 @@
+Search Portal Service
+=====================
+
+A REST API build with Django and Django Rest Framework.
+There is an admin available to inspect the data.
+
+All commands in this readme get run from the ``service`` directory.
+
+
+Installation
+------------
+
+After the [initial Python/machine installation](../README.md#installation) 
+and following the [getting started with the services guide](../README.md#getting-started)
+you can further setup your Django database for the API with the following commands.
+
+```bash
+export DJANGO_POSTGRES_USER=postgres  # the root user who will own all tables
+python manage.py migrate
+```
+
+This should have setup your database for the most part.
+Unfortunately due to historic reasons there is a lot of configuration going on in the database.
+So it's wise to get a production dump and import it to your system.
+Please ask somebody access to the S3 database dumps bucket.
+Place the latest dump inside ``postgres/dumps`` and then run:
+
+```bash
+make import-db backup=postgres/dumps/<dump-file-name>.sql
+```
+
+To finish the setup you can create a superuser for yourself using the ``createsuperuser`` command
+from the ``service`` directory.
+
+```bash
+python manage.py createsuperuser
+```
+
+
+Getting started
+---------------
+
+There are three ways to get the ``service`` component started.
+You can either start all services as explained in the [general getting started guide](../README.md#getting-started).
+Or you can start a local development server with:
+
+```bash
+make run-django
+```
+
+The last option is to start a container outside of docker-compose orchestration.
+This makes it easier to connect a debugger to it.
+Start a container with a UWSGI production server with:
+
+```bash
+make run-service-container
+```
+
+
+#### Available apps
+
+Either way the Django admin and API endpoints become available under:
+
+```bash
+http://localhost:8000/admin/
+http://localhost:8000/api/v1/
+```
+
+
+#### Migrate locally
+
+Database tables are owned by the root database user called "postgres".
+This is a different user than the application database user.
+and that causes problems when you try to migrate,
+because the application user is not allowed to alter or create anything.
+
+To apply migrations locally you'll need to switch the connection to the root user.
+You can do so by setting an environment variable before running the migration:
+
+```bash
+export DJANGO_POSTGRES_USER=postgres
+python manage.py migrate
+```
+
+
+Tests
+-----
+
+The test suite is rather limited at the moment. There's not real tests at all for the portal.
+However there are some tests for the integration with
+the Edurep search engine and our own Elastic Search powered engine.
+These engines are what makes the portal tick in the end
+and currently you can switch between the two engines with a deploy.
+The adapter that connects to these search engines is fully tested.
+These tests also assert that the two engines return more or less the same content.
+This is to keep the ability to switch engines when needed.
+
+Run these integration tests with the following command:
+
+```bash
+make integration-tests
+```
+


### PR DESCRIPTION
Ik heb de documentatie wat gerefactored, omdat het anders erg lastig werd om alle verschillende mogelijkheden te documenteren. Gevolg is dat ``make run-django`` verplaatst is naar ``service`` directory. Dit is denk ik onvermijdelijk, want ``make run-django`` in root context is ambigue. Gaat het dan over service of harvester?

Voor de rest weinig tot geen extra documentatie toegevoegd. Dat komt in latere PR's.