### PR TITLE
Fix deploy script to prevent app from starting in APPLICATION_MODE

### DIFF
--- a/environments/acceptance/invoke.yml
+++ b/environments/acceptance/invoke.yml
@@ -37,10 +37,7 @@ secrets:
     password: "arn:aws:secretsmanager:eu-central-1:000428825067:secret:search-portal/elastic-1xprrT"
 
 aws:
-  cluster_arn: "arn:aws:ecs:eu-central-1:000428825067:cluster/surfpol"
   image_upload_bucket: "search-portal-media-uploads-acc"
-  profile_name: "pol-acc"
-  task_role_arn: "arn:aws:iam::000428825067:role/ecsTaskExecutionRole"
 
   # The legacy mechanism to be able to override postgres credentials during migrations
   # Keeping this around for now until we move to AWS Secrets Manager fully

--- a/environments/development/invoke.yml
+++ b/environments/development/invoke.yml
@@ -41,10 +41,7 @@ secrets:
     password: "arn:aws:secretsmanager:eu-central-1:322480324822:secret:dev/search-portal/elastic-ByS7CH"
 
 aws:
-  cluster_arn: "arn:aws:ecs:eu-central-1:322480324822:cluster/surfpol"
   image_upload_bucket: "search-portal-media-uploads-dev"
-  profile_name: "pol-dev"
-  task_role_arn: "arn:aws:iam::322480324822:role/ecsTaskExecutionRole"
 
 # The legacy mechanism to be able to override postgres credentials during migrations
 # Keeping this around for now until we move to AWS Secrets Manager fully

--- a/environments/surfpol/configuration.py
+++ b/environments/surfpol/configuration.py
@@ -72,8 +72,7 @@ for group_name, group_secrets in secrets.items():
             aws_secrets.append((group_name, secret_name, secret_id,))
 # Here we found AWS secrets which we load using boto3
 if aws_secrets:
-    session = boto3.Session(profile_name=environment.aws.profile_name)
-    secrets_manager = session.client('secretsmanager')
+    secrets_manager = boto3.client('secretsmanager')
     for group_name, secret_name, secret_id in aws_secrets:
         secret_value = secrets_manager.get_secret_value(SecretId=secret_id)
         secret_payload = json.loads(secret_value["SecretString"])

--- a/service/package.py
+++ b/service/package.py
@@ -1,3 +1,3 @@
-VERSION = "1.7.0"
+VERSION = "1.7.1"
 NAME = "search-portal"
 REPOSITORY = "322480324822.dkr.ecr.eu-central-1.amazonaws.com"


### PR DESCRIPTION
Problem was that on deployments the whole application was being loaded in the APPLICATION_MODE that was provided. When `APPLICATION_MODE=acceptance` was provided this would also try to fetch the secrets from AWS (and possible other acceptance related stuff). 

Reason the application started in a specific mode seems to be to load AWS info from the config.
As we only use this information for deploying I moved it to the deployment script. This way we don't have to start the application in APPLICATION_MODE during a deployment.