### PR TITLE
Run python linter

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,4 @@
-name: pycodestyle
+name: Python lint
 
 on:
   [push, pull_request]
@@ -21,6 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run pycodestyle
+    - name: Run flake8
       run: |
-        pycodestyle .
+        flake8 .

--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -1,0 +1,26 @@
+name: pycodestyle
+
+on:
+  [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run pycodestyle
+      run: |
+        pycodestyle .

--- a/README.md
+++ b/README.md
@@ -221,3 +221,12 @@ To load snapshot data into the database on an AWS environment run:
 ```bash
 APPLICATION_MODE=<environment> fab -H <bastion-host-domain> db.restore-snapshot
 ```
+
+Linting
+-------
+
+The python code uses flake8 as a linter. You can run it with the following command:
+
+```bash
+flake8 .
+```

--- a/deploy.py
+++ b/deploy.py
@@ -14,9 +14,9 @@ from service.package import (
 )
 from harvester.package import VERSION as HARVESTER_VERSION
 
-
+# TODO: perhaps simply input a PACKAGE from <target>/package.py which is a dict like below and work with that directly
 TARGETS = {
-    "service": {  # TODO: perhaps simply input a PACKAGE from <target>/package.py which is a dict like below and work with that directly
+    "service": {
         "name": SERVICE_NAME,
         "repository": SERVICE_REPOSITORY,
         "version": SERVICE_VERSION

--- a/environments/surfpol/configuration.py
+++ b/environments/surfpol/configuration.py
@@ -20,7 +20,6 @@ import os
 import json
 from invoke.config import Config
 import boto3
-from botocore.exceptions import ClientError
 
 
 MODE = os.environ.get("APPLICATION_MODE", "production")

--- a/harvester/core/models/datatypes/arrangement.py
+++ b/harvester/core/models/datatypes/arrangement.py
@@ -42,7 +42,8 @@ class Arrangement(DocumentCollectionMixin, CollectionBase):
             # if multiple objects with an identifier of "by" exist.
             updated = set()
             hashed = {update[by_reference]: update for update in updates}
-            sources = {source[by_reference]: source for source in collection.documents.filter(reference__in=hashed.keys())}
+            sources = {source[by_reference]: source for source in collection.documents.filter(
+                reference__in=hashed.keys())}
             for source in sources.values():
                 source.update(hashed[source.reference], validate=validate)
                 count += 1

--- a/harvester/core/models/oaipmh.py
+++ b/harvester/core/models/oaipmh.py
@@ -10,7 +10,8 @@ class OAIPMHRepositories:
 
 
 OAIPMH_REPOSITORY_CHOICES = [
-    (attr.lower().capitalize(), value) for attr, value in sorted(OAIPMHRepositories.__dict__.items()) if not attr.startswith("_")
+    (attr.lower().capitalize(), value)
+    for attr, value in sorted(OAIPMHRepositories.__dict__.items()) if not attr.startswith("_")
 ]
 
 

--- a/harvester/core/models/search.py
+++ b/harvester/core/models/search.py
@@ -153,8 +153,8 @@ class ElasticIndex(models.Model):
                         'disciplines': {
                             'type': 'keyword'
                         },
-                        "suggest" : {
-                            "type" : "completion"
+                        "suggest": {
+                            "type": "completion"
                         },
                     }
                 }

--- a/harvester/core/tests.py
+++ b/harvester/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/harvester/core/views.py
+++ b/harvester/core/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/harvester/edurep/models.py
+++ b/harvester/edurep/models.py
@@ -17,7 +17,7 @@ class EdurepOAIPMH(HttpResource):
                 },
                 {
                     "type": "string",
-                    "pattern": "^\d{4}-\d{2}-\d{2}(T\d{2}\:\d{2}\:\d{2}Z)?$"
+                    "pattern": r"^\d{4}-\d{2}-\d{2}(T\d{2}\:\d{2}\:\d{2}Z)?$"
                 }
             ],
             "minItems": 1,

--- a/harvester/edurep/tests/commands/harvest_edurep_seeds.py
+++ b/harvester/edurep/tests/commands/harvest_edurep_seeds.py
@@ -74,7 +74,7 @@ class TestSeedHarvest(TestCase):
 
     def test_edurep_down(self):
         out = StringIO()
-        with patch("edurep.management.commands.harvest_edurep_seeds.send", return_value=([], [100],)) as send_mock:
+        with patch("edurep.management.commands.harvest_edurep_seeds.send", return_value=([], [100],)):
             try:
                 call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", stdout=out)
                 self.fail("harvest_edurep_seeds did not fail when EdurepOAIPMH was returning errors")

--- a/harvester/edurep/tests/utils.py
+++ b/harvester/edurep/tests/utils.py
@@ -18,13 +18,13 @@ class TestGetEdurepOAIPMHSeeds(TestCase):
         deleted = next(
             (seed for seed in seeds if seed["state"] == "deleted"), None
         )
-        imscp = next(
-            (seed for seed in seeds if seed["url"] and "maken.wikiwijs.nl" in seed["url"]), None
-        )
+        # imscp = next(
+        #     (seed for seed in seeds if seed["url"] and "maken.wikiwijs.nl" in seed["url"]), None
+        # )
         return {
             "normal": normal,
             "deleted": deleted,
-            #"imscp": imscp
+            # "imscp": imscp
         }
 
     def check_seed_integrity(self, seeds, include_deleted=True):
@@ -62,6 +62,7 @@ class TestGetEdurepOAIPMHSeeds(TestCase):
         self.check_seed_integrity(seeds, include_deleted=False)
 
     def test_get_partial_set_without_deletes(self):
-        seeds = get_edurep_oaipmh_seeds("surf", make_aware(datetime(year=2020, month=2, day=10, hour=22, minute=22)), include_deleted=False)
+        seeds = get_edurep_oaipmh_seeds("surf", make_aware(
+            datetime(year=2020, month=2, day=10, hour=22, minute=22)), include_deleted=False)
         self.assertEqual(len(seeds), 4)
         self.check_seed_integrity(seeds, include_deleted=False)

--- a/harvester/edurep/views.py
+++ b/harvester/edurep/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # That way we can load the environments and re-use them in different contexts
 # Like maintenance tasks and harvesting tasks
 sys.path.append(os.path.join(BASE_DIR, "..", "environments"))
-from surfpol import create_configuration_and_session, MODE, get_package_info
+from surfpol import create_configuration_and_session, get_package_info
 # Then we read some variables from the (build) environment
 PACKAGE_INFO = get_package_info()
 GIT_COMMIT = PACKAGE_INFO.get("commit", "unknown-git-commit")
@@ -193,10 +193,10 @@ MIME_TYPE_TO_FILE_TYPE = {  # TODO: this is Edurep based, how do we want this fo
     'application/vnd.ms-word': 'text',
     'application/vnd.ms-word.document.macroEnabled.12': 'text',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.template': 'text',
-    'text/rtf':	'text',
+    'text/rtf': 'text',
     'application/xhtml+xml': 'text',
     'application/postscript': 'text',
-    'application/vnd.ms-publisher':	'text',
+    'application/vnd.ms-publisher': 'text',
     'text/xml': 'text',
     'application/vnd.oasis.opendocument.spreadsheet': 'spreadsheet',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'spreadsheet',
@@ -228,18 +228,18 @@ MIME_TYPE_TO_FILE_TYPE = {  # TODO: this is Edurep based, how do we want this fo
     'application/x-Wikiwijs-Arrangement': 'archive',
     'audio/mpeg': 'audio',
     'application/x-koan': 'audio',
-    'application/vnd.koan':	'audio',
+    'application/vnd.koan': 'audio',
     'audio/midi': 'audio',
     'audio/x-wav': 'audio',
     'application/octet-stream': 'other',
-    'application/x-yossymemo':	'digiboard',
+    'application/x-yossymemo': 'digiboard',
     'application/Inspire': 'digiboard',
     'application/x-AS3PE': 'digiboard',
     'application/x-Inspire': 'digiboard',
     'application/x-smarttech-notebook': 'digiboard',
     'application/x-zip-compressed': 'digiboard',
     'application/x-ACTIVprimary3': 'digiboard',
-    'application/x-ibooks+zip':	'ebook',
+    'application/x-ibooks+zip': 'ebook',
     'message/rfc822': 'message',
     'application/vnd.google-earth.kmz': 'googleearth',
     'application/x-java': 'app',

--- a/postgres/tasks_remote.py
+++ b/postgres/tasks_remote.py
@@ -13,7 +13,7 @@ def setup(ctx):
     # Setup auto-responder
     postgres_user = ctx.config.django.postgres_user
     postgres_password = ctx.config.secrets.postgres.password
-    postgres_password_responder = Responder(pattern="Password", response= postgres_password + "\n")
+    postgres_password_responder = Responder(pattern="Password", response=postgres_password + "\n")
     # Run Postgres commands with port forwarding
     with ctx.forward_local(local_port=1111, remote_host=ctx.config.django.postgres_host, remote_port=5432):
         # Clear all databases and application role

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Development
 gitpython==3.1.0
+flake8==3.8.3
 
 # Common
 django==2.2.13

--- a/service/e2e_tests/test_basic_search.py
+++ b/service/e2e_tests/test_basic_search.py
@@ -1,5 +1,6 @@
 from e2e_tests.base import BaseTestCase
 
+
 class TestBasicSearch(BaseTestCase):
     def test_home_page(self):
         self.selenium.get(self.live_server_url)

--- a/service/surf/apps/communities/admin.py
+++ b/service/surf/apps/communities/admin.py
@@ -72,7 +72,7 @@ class CommunityDetailInlineFormset(forms.models.BaseInlineFormSet):
                 language_code = form.cleaned_data['language_code'].upper()
                 if language_code in languages:
                     languages.remove(language_code)
-            except KeyError as exc:
+            except KeyError:
                 continue
         if len(languages) != 0:
             raise ValidationError(f"Required language code(s) '{', '.join(languages)}' not in community details.")

--- a/service/surf/apps/communities/models.py
+++ b/service/surf/apps/communities/models.py
@@ -14,7 +14,6 @@ from django_enumfield import enum
 from surf.apps.core.models import UUIDModel
 
 from surf.apps.materials.models import Collection
-from surf.apps.locale.models import Locale, LocaleHTML
 from surf.statusenums import PublishStatus
 
 REQUIRED_LANGUAGES = ['NL', 'EN']

--- a/service/surf/apps/communities/serializers.py
+++ b/service/surf/apps/communities/serializers.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from surf.apps.communities.models import Community, CommunityDetail
-from surf.apps.communities.models import PublishStatus
 from surf.apps.filters.models import MpttFilterItem
 from surf.apps.filters.serializers import MpttFilterItemSerializer
 from surf.apps.filters.utils import add_default_material_filters

--- a/service/surf/apps/core/views.py
+++ b/service/surf/apps/core/views.py
@@ -9,6 +9,6 @@ from rest_framework.permissions import AllowAny
 @permission_classes([AllowAny])
 @schema(None)
 def health_check(request):
-    data = {"healthy" : True}
+    data = {"healthy": True}
     data.update(settings.PACKAGE_INFO)
     return Response(data, status.HTTP_200_OK)

--- a/service/surf/apps/filters/tests.py
+++ b/service/surf/apps/filters/tests.py
@@ -24,7 +24,8 @@ class TestFilters(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(number_of_categories, 9)
-        self.assertEqual(names, ['Bron', 'Bruikbaar als', 'Gebruiksrechten', 'Onderwijsniveau', 'Publicatiedatum', 'Soort materiaal', 'Taal', 'Thema', 'Vakgebied'])
+        self.assertEqual(names, ['Bron', 'Bruikbaar als', 'Gebruiksrechten', 'Onderwijsniveau',
+                                 'Publicatiedatum', 'Soort materiaal', 'Taal', 'Thema', 'Vakgebied'])
 
         self.assertTrue(parent_in_filter_category, msg=None)
         self.assertTrue(external_id_in_filter_category, msg=None)

--- a/service/surf/apps/filters/views.py
+++ b/service/surf/apps/filters/views.py
@@ -47,8 +47,7 @@ class FilterCategoryViewSet(ListModelMixin, GenericViewSet):
             for child in input_node['children']:
                 self.remove_zero_counts(child)
             input_node['children'] = [child for child in input_node['children']
-                                      if child['item_count'] > 0
-                                      or len(child['children']) > 0]
+                                      if child['item_count'] > 0 or len(child['children']) > 0]
 
     def list(self, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
@@ -120,5 +119,3 @@ class FilterViewSet(ModelViewSet):
 
 class MpttFilterItems(generics.GenericAPIView):
     serializer_class = MpttFilterItemSerializer
-
-

--- a/service/surf/apps/materials/admin.py
+++ b/service/surf/apps/materials/admin.py
@@ -5,7 +5,6 @@ This module provides django admin functionality for materials app.
 from django.contrib import admin
 
 from surf.apps.materials import models
-from surf.apps.materials.utils import update_materials_data
 
 
 def trash_nodes(modeladmin, request, queryset):

--- a/service/surf/apps/materials/models.py
+++ b/service/surf/apps/materials/models.py
@@ -3,9 +3,7 @@ This module contains implementation of models for materials app.
 """
 
 import json
-from datetime import datetime
 
-from django.conf import settings
 from django.db import models as django_models
 from django.db.models import F
 from django.utils import timezone

--- a/service/surf/apps/materials/serializers.py
+++ b/service/surf/apps/materials/serializers.py
@@ -182,7 +182,7 @@ class CollectionSerializer(CollectionShortSerializer):
 
     def validate(self, attrs):
         if not self.get_materials_count(self.instance) and attrs.get("publish_status", None) == PublishStatus.PUBLISHED:
-           raise ValidationError("Can't publish a collection if it doesn't have materials")
+            raise ValidationError("Can't publish a collection if it doesn't have materials")
         return attrs
 
     @staticmethod

--- a/service/surf/apps/materials/utils.py
+++ b/service/surf/apps/materials/utils.py
@@ -4,8 +4,6 @@ This module contains some common functions for materials app.
 
 import json
 
-from django.conf import settings
-
 from surf.apps.communities.models import Community
 from surf.apps.filters.models import MpttFilterItem
 from surf.apps.materials.models import (

--- a/service/surf/apps/materials/views.py
+++ b/service/surf/apps/materials/views.py
@@ -164,8 +164,7 @@ def _get_filter_categories():
     :return: list of "edurep_field_id:item_count"
     """
     return [f.external_id for f in MpttFilterItem.objects.all()
-            if f.external_id not in IGNORED_FIELDS
-            and f.level == 0]
+            if f.external_id not in IGNORED_FIELDS and f.level == 0]
 
 
 class KeywordsAPIView(APIView):
@@ -226,10 +225,10 @@ class MaterialAPIView(APIView):
             filters = add_default_material_filters()
 
             res = elastic.search([],
-                            # sort by newest items first
-                            ordering="-lom.lifecycle.contribute.publisherdate",
-                            filters=filters,
-                            page_size=_MATERIALS_COUNT_IN_OVERVIEW)
+                                 # sort by newest items first
+                                 ordering="-lom.lifecycle.contribute.publisherdate",
+                                 filters=filters,
+                                 page_size=_MATERIALS_COUNT_IN_OVERVIEW)
 
             res = add_extra_parameters_to_materials(request.user,
                                                     res["records"])
@@ -457,7 +456,7 @@ class CollectionViewSet(ModelViewSet):
             if not details:
                 continue
 
-            keywords =details[0].get("keywords")
+            keywords = details[0].get("keywords")
             if keywords:
                 keywords = json.dumps(keywords)
 
@@ -507,7 +506,7 @@ def check_access_to_collection(user, instance=None):
         communities = Community.objects.filter(collections__in=[instance])
         teams = Team.objects.filter(community__in=communities, user=user)
         if len(teams) > 0:
-            logger.debug(f"At least one team satisfies the requirement of be able to delete this collection.")
+            logger.debug("At least one team satisfies the requirement of be able to delete this collection.")
         else:
             raise AuthenticationFailed(f"User {user} is not a member of any community with collection {instance}. "
                                        f"Error: \"{exc}\"")
@@ -521,7 +520,7 @@ def add_share_counters_to_materials(materials):
     """
 
     for m in materials:
-        key = SharedResourceCounter.create_counter_key(RESOURCE_TYPE_MATERIAL,m["external_id"])
+        key = SharedResourceCounter.create_counter_key(RESOURCE_TYPE_MATERIAL, m["external_id"])
         qs = SharedResourceCounter.objects.filter(counter_key__contains=key)
         m["sharing_counters"] = SharedResourceCounterSerializer(many=True).to_representation(qs.all())
 

--- a/service/surf/apps/themes/admin.py
+++ b/service/surf/apps/themes/admin.py
@@ -18,6 +18,7 @@ class ThemeForm(forms.ModelForm):
     """
     Implementation of Theme Form class.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/service/surf/settings/base.py
+++ b/service/surf/settings/base.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/2.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
+
 import sys
 import os
 import sentry_sdk
@@ -18,12 +19,12 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(BASE_DIR, "..", "..", "environments"))
+from surfpol import create_configuration_and_session, MODE, CONTEXT, get_package_info
 
 # We're adding the environments directory outside of the project directory to the path
 # That way we can load the environments and re-use them in different contexts
 # Like maintenance tasks and harvesting tasks
-sys.path.append(os.path.join(BASE_DIR, "..", "..", "environments"))
-from surfpol import create_configuration_and_session, MODE, CONTEXT, get_package_info
 PACKAGE_INFO = get_package_info()
 environment, session = create_configuration_and_session()
 

--- a/service/surf/statusenums.py
+++ b/service/surf/statusenums.py
@@ -11,5 +11,3 @@ class PublishStatus(enum.Enum):  # NB: this enum has a hard copy in the webapp
         REVIEW: "Review",
         PUBLISHED: "Published",
     }
-
-

--- a/service/surf/vendor/edurep/smb/soap/api.py
+++ b/service/surf/vendor/edurep/smb/soap/api.py
@@ -51,6 +51,7 @@ class SmbSoapApiClient:
     """
     Class provides integration with SMB SOAP-service
     """
+
     def __init__(self, api_endpoint=_DEFAULT_API_ENDPOINT):
         self.api_endpoint = api_endpoint
 

--- a/service/surf/vendor/search/tests/tests_elastic_search.py
+++ b/service/surf/vendor/search/tests/tests_elastic_search.py
@@ -12,7 +12,8 @@ class TestsElasticSearch(TestCase):
 
     def test_basic_search(self):
         search_result = self.instance.search([])
-        search_result_filter = self.instance.search([], filters=[{"external_id": "lom.technical.format", "items": ["video"]}])
+        search_result_filter = self.instance.search(
+            [], filters=[{"external_id": "lom.technical.format", "items": ["video"]}])
         # did we get _anything_ from search?
         self.assertIsNotNone(search_result)
         self.assertIsNotNone(search_result_filter)
@@ -203,13 +204,13 @@ class TestsElasticSearch(TestCase):
 
     def test_drilldowns(self):
         empty_drilldowns = self.instance.drilldowns(drilldown_names=[])
-        #{'recordcount': 1298193, 'records': [], 'drilldowns': []}
+        # {'recordcount': 1298193, 'records': [], 'drilldowns': []}
         self.assertGreater(empty_drilldowns['recordcount'], 0)
         self.assertFalse(empty_drilldowns['records'])
         self.assertFalse(empty_drilldowns['drilldowns'])
 
         biologie_drilldowns = self.instance.drilldowns([], search_text=["biologie"])
-        #{'recordcount': 32, 'records': [], 'drilldowns': []}
+        # {'recordcount': 32, 'records': [], 'drilldowns': []}
         self.assertGreater(biologie_drilldowns['recordcount'], 0)
         self.assertGreater(empty_drilldowns['recordcount'], biologie_drilldowns['recordcount'])
         self.assertFalse(biologie_drilldowns['records'])
@@ -233,10 +234,6 @@ class TestsElasticSearch(TestCase):
     def test_get_materials_by_id(self):
 
         def test_material(external_id):
-            # can't test for theme and copyright without creating and instantiating these values in the database
-            material_keys = ['object_id', 'url', 'title', 'description', 'keywords', 'language',
-                             'publish_datetime', 'author', 'format', 'disciplines', 'educationallevels']
-
             result = self.instance.get_materials_by_id(external_ids=[external_id])
 
             self.assertIsNotNone(result)
@@ -253,7 +250,10 @@ class TestsElasticSearch(TestCase):
         self.assertIsNot(material_1, material_2)
 
         self.assertEqual(material_1['title'], 'Decision Trees and Random Decision Forests')
-        self.assertEqual(material_1['url'], 'https://surfsharekit.nl/dl/surf/bef89539-a037-454d-bee3-da09f4c94e0b/53c7bb36-e374-431c-a50c-e208ab53e412')
+        self.assertEqual(
+            material_1['url'],
+            'https://surfsharekit.nl/dl/surf/bef89539-a037-454d-bee3-da09f4c94e0b/53c7bb36-e374-431c-a50c-e208ab53e412'
+        )
         self.assertEqual(material_1['external_id'], test_id_1)
         self.assertEqual(material_1['publish_datetime'], None)
         self.assertEqual(material_1['author'], None)
@@ -263,9 +263,16 @@ class TestsElasticSearch(TestCase):
         self.assertEqual(material_1['format'], 'pdf')
 
         self.assertEqual(material_2['title'], '07 AS_AD model')
-        self.assertEqual(material_2['url'], 'https://surfsharekit.nl/dl/surf/651a50f7-8942-4615-af67-a6841e00b78b/bf30be37-dc7c-4106-8ef4-9773b48b547b')
+        self.assertEqual(
+            material_2['url'],
+            'https://surfsharekit.nl/dl/surf/651a50f7-8942-4615-af67-a6841e00b78b/bf30be37-dc7c-4106-8ef4-9773b48b547b'
+        )
         self.assertEqual(material_2['external_id'], test_id_2)
-        self.assertEqual(material_2['keywords'], ['economics', 'macro economics', 'micro economics', 'economic structure', 'inflationary gap', 'deflationary gap', 'full-employment equilibrium'])
+        self.assertEqual(
+            material_2['keywords'],
+            ['economics', 'macro economics', 'micro economics',
+             'economic structure', 'inflationary gap', 'deflationary gap', 'full-employment equilibrium']
+        )
         self.assertEqual(material_2['publish_datetime'], '2019-04-01')
         self.assertEqual(material_2['language'], 'en')
         self.assertEqual(material_2['author'], 'Dr. Ning Ding')

--- a/service/surf/vendor/surfconext/models/privacy.py
+++ b/service/surf/vendor/surfconext/models/privacy.py
@@ -174,5 +174,6 @@ class DataGoalPermissionSerializer(serializers.ModelSerializer):
     class Meta:
         model = DataGoalPermission
         list_serializer_class = DataGoalPermissionListSerializer
-        fields = ("id", "type", "en", "nl", "more_info_route", "priority", "is_notification_only", "is_after_login", "is_allowed")
+        fields = ("id", "type", "en", "nl", "more_info_route", "priority",
+                  "is_notification_only", "is_after_login", "is_allowed")
         read_only_fields = ("en", "nl", "more_info_route", "priority", "is_notification_only", "is_after_login")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 120
+exclude = migrations,fixtures,elasticsearch_fixtures,venv,node_modules
+per-file-ignores =
+  */__init__.py:F401
+  service/surf/settings/base.py:E402
+  service/surf/settings/tests.py:F403,F405
+  service/surf/settings/service.py:F401,F403
+  harvester/harvester/settings.py:E402

--- a/test.py
+++ b/test.py
@@ -16,25 +16,25 @@ def prepare_e2e_tests(ctx):
 @task(prepare_e2e_tests)
 def e2e_tests(ctx):
     with ctx.cd("service"):
-        ctx.run(f"python manage.py test e2e_tests", echo=True, pty=True)
+        ctx.run("python manage.py test e2e_tests", echo=True, pty=True)
 
 
 @task
 def service_tests(ctx):
     with ctx.cd("service"):
-        ctx.run(f"python manage.py test surf.apps", echo=True, pty=True)
+        ctx.run("python manage.py test surf.apps", echo=True, pty=True)
 
 
 @task
 def elastic_search_tests(ctx):
     with ctx.cd("service"):
-        ctx.run(f"python manage.py test surf.vendor", echo=True, pty=True)
+        ctx.run("python manage.py test surf.vendor", echo=True, pty=True)
 
 
 @task
 def harvester_tests(ctx):
     with ctx.cd("harvester"):
-        ctx.run(f"python manage.py test", echo=True, pty=True)
+        ctx.run("python manage.py test", echo=True, pty=True)
 
 
 @task(service_tests, harvester_tests, e2e_tests)


### PR DESCRIPTION
Runs flake8 for every build.

Flake8 uses pycodestyle (which was pep8) and some more checks, like unused imports and variables.

I have fixed all the warnings and enabled it in the build. From now on we can make sure we won't introduce any new styling errors 🎉 .