### PR TITLE
Display line breaks in description

### DIFF
--- a/portal/src/components/Materials/MaterialInfo/MaterialInfo.component.less
+++ b/portal/src/components/Materials/MaterialInfo/MaterialInfo.component.less
@@ -46,6 +46,8 @@
       }
     }
     &_description {
+      white-space: pre-wrap;
+
       @media @desktop {
         margin-bottom: 53px;
       }


### PR DESCRIPTION
`white-space: pre-wrap` also displays line breaks. So this fixes the problem

![Screenshot 2020-06-26 at 10 46 00](https://user-images.githubusercontent.com/467437/85839076-c0759780-b79a-11ea-93ee-efa3ae8f77e1.png)
