### PR TITLE
Filter like bol.com

### DIFF
--- a/portal/src/components/FilterCategories/FilterCategories.component.js
+++ b/portal/src/components/FilterCategories/FilterCategories.component.js
@@ -93,13 +93,6 @@ export default {
     },
     hasDatesRangeFilter() {
       return this.datesRangeFilter().some(item => item !== null)
-    },
-    sortFilterItems(items) {
-      const nullCounts = items.filter(item => item.count === null)
-      const sorted = items
-        .filter(item => item.count !== null)
-        .sort((a, b) => b.count - a.count)
-      return [...sorted, ...nullCounts]
     }
   },
   computed: {
@@ -132,8 +125,6 @@ export default {
           child.selected = selected.includes(child.external_id)
           return child
         })
-
-        category.children = this.sortFilterItems(category.children)
 
         return category
       })

--- a/portal/src/components/FilterCategories/FilterCategory/FilterCategory.vue
+++ b/portal/src/components/FilterCategories/FilterCategory/FilterCategory.vue
@@ -33,7 +33,7 @@
         </li>
 
         <li
-          v-if="category.children.length > visibleItems"
+          v-if="category.children.length > numberOfVisibleItems"
           class="filter-categories__subitem--show-more"
         >
           <a
@@ -81,12 +81,24 @@ export default {
     visible() {
       return this.category.children.some(child => !child.is_hidden)
     },
+    sortedChildren() {
+      return [...this.category.children].sort((a, b) => {
+        return b.selected - a.selected || b.count - a.count
+      })
+    },
+    numberOfVisibleItems() {
+      // Display all selected items or max visibleItems
+      return Math.max(
+        this.category.children.filter(c => c.selected).length,
+        this.visibleItems
+      )
+    },
     visibleChildren() {
       if (this.showAll) {
-        return this.category.children
+        return this.sortedChildren
       }
 
-      return this.category.children.slice(0, this.visibleItems)
+      return this.sortedChildren.slice(0, this.numberOfVisibleItems)
     }
   },
   methods: {

--- a/service/e2e_tests/elasticsearch_fixtures/elasticsearch.py
+++ b/service/e2e_tests/elasticsearch_fixtures/elasticsearch.py
@@ -16,7 +16,18 @@ NL_MATERIAL = {
         "BEGIN:VCARD\nVERSION:3.0\nPRODID:-//Sabre//Sabre VObject 3.3.5//EN\nFN:Theo van den Bogaart\nEND:VCARD",
         "BEGIN:VCARD\nVERSION:3.0\nPRODID:-//Sabre//Sabre VObject 3.3.5//EN\nFN:Marc de Graaf\nEND:VCARD"
     ],
-    "file_type": "archive",
+    "file_type": "text",
     "disciplines": [],
     "arrangement_collection_name": "wikiwijsmaken"
 }
+
+
+def generate_nl_material(educational_levels=None, file_type=None, source=None):
+    copy = NL_MATERIAL.copy()
+    if educational_levels:
+        copy["lom_educational_levels"] = educational_levels
+    if file_type:
+        copy["file_type"] = file_type
+    if source:
+        copy["arrangement_collection_name"] = source
+    return copy

--- a/service/e2e_tests/test_search.py
+++ b/service/e2e_tests/test_search.py
@@ -1,7 +1,10 @@
 from django.conf import settings
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 
 from e2e_tests.base import ElasticSearchTestCase
-from e2e_tests.elasticsearch_fixtures.elasticsearch import NL_MATERIAL
+from e2e_tests.elasticsearch_fixtures.elasticsearch import generate_nl_material
 
 
 class TestSearch(ElasticSearchTestCase):
@@ -10,7 +13,7 @@ class TestSearch(ElasticSearchTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.elastic.index(index=settings.ELASTICSEARCH_NL_INDEX, doc_type="_doc", body=NL_MATERIAL)
+        cls.elastic.index(index=settings.ELASTICSEARCH_NL_INDEX, doc_type="_doc", body=generate_nl_material())
 
     def test_search(self):
         self.selenium.get(self.live_server_url)
@@ -24,7 +27,7 @@ class TestSearch(ElasticSearchTestCase):
         self.selenium.find_element_by_xpath("//*[text()[contains(., 'Didactiek van wiskundig denken')]]")
 
     def test_search_by_author(self):
-        material_path = f"/materialen/{NL_MATERIAL.get('external_id')}"
+        material_path = f"/materialen/{generate_nl_material().get('external_id')}"
         self.selenium.get(f"{self.live_server_url}{material_path}")
 
         author_link = self.selenium.find_element_by_css_selector(".material__info_author a")
@@ -32,3 +35,106 @@ class TestSearch(ElasticSearchTestCase):
 
         search_results = self.selenium.find_elements_by_css_selector(".materials__item_wrapper.tile__wrapper")
         self.assertEqual(len(search_results), 1)
+
+
+class TestSearchFiltering(ElasticSearchTestCase):
+    fixtures = ['filter-categories', 'locales']
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.elastic.index(
+            index=settings.ELASTICSEARCH_NL_INDEX,
+            doc_type="_doc",
+            body=generate_nl_material(educational_levels=["HBO"], file_type="text", source="wikiwijsmaken")
+        )
+        cls.elastic.index(
+            index=settings.ELASTICSEARCH_NL_INDEX,
+            doc_type="_doc",
+            body=generate_nl_material(educational_levels=["WO"], file_type="text", source="wikiwijsmaken")
+        )
+        cls.elastic.index(
+            index=settings.ELASTICSEARCH_NL_INDEX,
+            doc_type="_doc",
+            body=generate_nl_material(educational_levels=["WO"], file_type="text", source="surf")
+        )
+        cls.elastic.index(
+            index=settings.ELASTICSEARCH_NL_INDEX,
+            doc_type="_doc",
+            body=generate_nl_material(educational_levels=["WO"], file_type="video", source="surf")
+        )
+        cls.elastic.index(
+            index=settings.ELASTICSEARCH_NL_INDEX,
+            doc_type="_doc",
+            body=generate_nl_material(educational_levels=["HBO"], file_type="video", source="surf")
+        )
+
+    def test_filter_search(self):
+        self.selenium.get(self.live_server_url)
+        self.selenium.find_element_by_css_selector(".search.main__info_search input[type=search]").send_keys("Wiskunde")
+        self.selenium.find_element_by_css_selector(".search.main__info_search button").click()
+
+        # Open filter categories
+        educational_levels = self.selenium.find_element_by_xpath("//li[.//h4[text()[contains(., 'Onderwijsniveau')]]]")
+        educational_levels.click()
+        file_types = self.selenium.find_element_by_xpath("//li[.//h4[text()[contains(., 'Soort materiaal')]]]")
+        file_types.click()
+        source_category = self.selenium.find_element_by_xpath("//li[.//h4[text()[contains(., 'Bron')]]]")
+        source_category.click()
+
+        # Initial filter state
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#video ~ label"), "Video (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#text ~ label"), "Tekst (3)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#WO ~ label"), "WO (3)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#HBO ~ label"), "HBO (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#surf ~ label"), "SURF (3)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#wikiwijsmaken ~ label"), "Wikiwijs Maken (2)"))
+
+        # Filter on WO
+        educational_levels.find_element_by_css_selector("input").click()
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#video ~ label"), "Video (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#text ~ label"), "Tekst (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#WO ~ label"), "WO (3)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#HBO ~ label"), "HBO (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#surf ~ label"), "SURF (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#wikiwijsmaken ~ label"), "Wikiwijs Maken (1)"))
+
+        # Filter on Tekst
+        file_types.find_element_by_css_selector("input").click()
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#WO ~ label"), "WO (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#HBO ~ label"), "HBO (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#video ~ label"), "Video (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#text ~ label"), "Tekst (2)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#surf ~ label"), "SURF (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#wikiwijsmaken ~ label"), "Wikiwijs Maken (1)"))
+
+        # Filter on SURF
+        source_category.find_element_by_css_selector("input").click()
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#WO ~ label"), "WO (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#video ~ label"), "Video (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#text ~ label"), "Tekst (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#surf ~ label"), "SURF (1)"))
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element((By.CSS_SELECTOR, "#wikiwijsmaken ~ label"), "Wikiwijs Maken (1)"))

--- a/service/surf/apps/communities/serializers.py
+++ b/service/surf/apps/communities/serializers.py
@@ -9,7 +9,6 @@ from rest_framework import serializers
 from surf.apps.communities.models import Community, CommunityDetail
 from surf.apps.filters.models import MpttFilterItem
 from surf.apps.filters.serializers import MpttFilterItemSerializer
-from surf.apps.filters.utils import add_default_material_filters
 from surf.vendor.elasticsearch.api import ElasticSearchApiClient
 from django.core.exceptions import ValidationError
 from rest_framework.exceptions import APIException
@@ -180,8 +179,6 @@ class CommunityDisciplineSerializer(MpttFilterItemSerializer):
         if obj.external_id:
             elastic = ElasticSearchApiClient()
             filters = [OrderedDict(external_id=obj.parent.external_id, items=[obj.external_id])]
-            tree = self.context["mptt_tree"]
-            filters = add_default_material_filters(filters, tree)
             res = elastic.search([], filters=filters, page_size=0)
             return res['recordcount']
 

--- a/service/surf/apps/filters/serializers.py
+++ b/service/surf/apps/filters/serializers.py
@@ -28,10 +28,7 @@ class MpttFilterItemSerializer(serializers.ModelSerializer):
             return []
         else:
             counts = self.context.get('search_counts', [])
-            if counts:
-                return MpttFilterItemSerializer(obj.get_children(), many=True, context={'search_counts': counts}).data
-            else:
-                return MpttFilterItemSerializer(obj.get_children(), many=True).data
+            return MpttFilterItemSerializer(obj.get_children(), many=True, context={'search_counts': counts}).data
 
     def get_count(self, obj):
         search_counts = self.context.get('search_counts', [])
@@ -39,7 +36,7 @@ class MpttFilterItemSerializer(serializers.ModelSerializer):
             item = search_counts.get(obj.external_id, None)
             if item:
                 return item.get('count', 0)
-        return
+        return 0
 
     class Meta:
         model = models.MpttFilterItem

--- a/service/surf/apps/filters/utils.py
+++ b/service/surf/apps/filters/utils.py
@@ -28,40 +28,6 @@ _MBO_HBO_WO_REGEX = re.compile(r"^(MBO|HBO|WO)(.*)$", re.IGNORECASE)
 _HBO_WO_REGEX = re.compile(r"^(HBO|WO)(.*)$", re.IGNORECASE)
 
 
-def add_default_material_filters(filters=None, tree=None):
-    """
-    Adds the default enabled filters to the supplied list of filters.
-    In the filter admin there is a check to enable a filter by default, these get used here.
-    Much like a google search will default to your language unless you specifically tell it otherwise,
-    this allows us to enable certain filter items like education level and copyright by default.
-    :param filters: list of filters to be extended, or None to get the full list of default filters,
-    :param tree: mptt filter category item tree to use instead of querying the database (to speed up the method).
-    :return: the extended list of filters (or the same list if none are enabled by default)
-    """
-    if not filters:
-        filters = []
-    if not tree:
-        tree = MpttFilterItem.objects.get_cached_trees()
-
-    filters_external_id_list = [filter_item['external_id'] for filter_item in filters]
-    for root in tree:
-        # if the root.external_id (e.g. educational_level) is in the user-selected filters,
-        # then don't add the default filters for that root. So if a user selects 'HBO', don't also default to 'WO'.
-        # And if a node that is enabled by default has children, they're enabled by default as well.
-        if root.external_id not in filters_external_id_list:
-            enabled_children = root.get_children()
-            if not root.enabled_by_default:
-                enabled_children = [child for child in enabled_children if child.enabled_by_default]
-            child_external_ids = []
-            for child in enabled_children:
-                child_external_ids.extend([grand_child.external_id for grand_child in child.get_children()])
-            if enabled_children:
-                # if child.external_id is empty don't append it to the filters, edurep fails on empty strings
-                child_external_ids.extend([child.external_id for child in enabled_children if child.external_id])
-            filters.append(OrderedDict(external_id=root.external_id, items=child_external_ids))
-    return filters
-
-
 def check_and_update_mptt_filters():
     """
     Updates all filter categories and their items in database according to information from Edurep.

--- a/service/surf/apps/filters/utils.py
+++ b/service/surf/apps/filters/utils.py
@@ -4,7 +4,6 @@ This module contains some common functions for filters app.
 
 import datetime
 import re
-from collections import OrderedDict
 
 from django.conf import settings
 from tqdm import tqdm

--- a/service/surf/apps/materials/views.py
+++ b/service/surf/apps/materials/views.py
@@ -22,7 +22,7 @@ from rest_framework.viewsets import (
 from surf.apps.communities.models import Team, Community
 from surf.apps.filters.models import MpttFilterItem
 from surf.apps.filters.serializers import MpttFilterItemSerializer
-from surf.apps.filters.utils import IGNORED_FIELDS, add_default_material_filters
+from surf.apps.filters.utils import IGNORED_FIELDS
 from surf.apps.materials.filters import (
     CollectionFilter
 )
@@ -113,9 +113,6 @@ class MaterialSearchAPIView(APIView):
             filters.append(dict(external_id=AUTHOR_FIELD_ID, items=[author]))
 
         data["filters"] = filters
-
-        # add default filters to search materials
-        data["default_filters"] = add_default_material_filters([])
 
         return_records = data.pop("return_records", None)
         return_filters = data.pop("return_filters", None)
@@ -239,13 +236,9 @@ class MaterialAPIView(APIView):
             # return overview of newest Materials
             elastic = ElasticSearchApiClient()
 
-            # add default filters to search materials
-            filters = add_default_material_filters()
-
             res = elastic.search([],
                                  # sort by newest items first
                                  ordering="-lom.lifecycle.contribute.publisherdate",
-                                 filters=filters,
                                  page_size=_MATERIALS_COUNT_IN_OVERVIEW)
 
             res = add_extra_parameters_to_materials(request.user,

--- a/service/surf/apps/materials/views.py
+++ b/service/surf/apps/materials/views.py
@@ -112,10 +112,10 @@ class MaterialSearchAPIView(APIView):
         if author:
             filters.append(dict(external_id=AUTHOR_FIELD_ID, items=[author]))
 
-        # add default filters to search materials
-        filters = add_default_material_filters(filters)
-
         data["filters"] = filters
+
+        # add default filters to search materials
+        data["default_filters"] = add_default_material_filters([])
 
         return_records = data.pop("return_records", None)
         return_filters = data.pop("return_filters", None)

--- a/service/surf/apps/stats/views.py
+++ b/service/surf/apps/stats/views.py
@@ -6,7 +6,6 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from surf.apps.filters.utils import add_default_material_filters
 from surf.vendor.elasticsearch.api import ElasticSearchApiClient
 
 
@@ -25,6 +24,5 @@ class StatsView(ViewSet):
 
         elastic = ElasticSearchApiClient()
 
-        filters = add_default_material_filters()
-        res = elastic.search([], filters=filters, page_size=0)
+        res = elastic.search([], page_size=0)
         return Response(dict(value=res.get("recordcount", 0)))

--- a/service/surf/apps/themes/serializers.py
+++ b/service/surf/apps/themes/serializers.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 from rest_framework import serializers
 
-from surf.apps.filters.utils import add_default_material_filters
 from surf.apps.themes.models import Theme
 from surf.apps.filters.models import MpttFilterItem
 from surf.apps.locale.serializers import LocaleSerializer, LocaleHTMLSerializer
@@ -39,8 +38,6 @@ class ThemeDisciplineSerializer(MpttFilterItemSerializer):
         if obj.external_id:
             elastic = ElasticSearchApiClient()
             filters = [OrderedDict(external_id=obj.parent.external_id, items=[obj.external_id])]
-            tree = self.context["mptt_tree"]
-            filters = add_default_material_filters(filters, tree)
             res = elastic.search([], filters=filters, page_size=0)
             return res['recordcount']
 

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -293,9 +293,12 @@ class ElasticSearchApiClient:
 
         aggregation_items = {}
         for aggregation_name in aggregation_names:
+            other_filters = []
 
-            other_filters = list(filter(lambda x: x['external_id'] != aggregation_name, filters))
-            other_filters = self.parse_filters(other_filters)
+            if filters:
+                other_filters = list(filter(lambda x: x['external_id'] != aggregation_name, filters))
+                other_filters = self.parse_filters(other_filters)
+
             elastic_type = ElasticSearchApiClient.translate_external_id_to_elastic_type(aggregation_name)
 
             if len(other_filters) > 0:

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -145,7 +145,6 @@ class ElasticSearchApiClient:
     def search(
             self,
             search_text: list,
-            default_filters=None,
             drilldown_names=None,
             filters=None,
             ordering=None,
@@ -156,7 +155,6 @@ class ElasticSearchApiClient:
         Build and send a query to elasticsearch and parse it before returning.
         :param search_text: A list of strings to search for.
         :param drilldown_names: A list of the 'drilldowns' (filters) that are to be counted by elasticsearch.
-        :param default_filters: The filters that are applied by default for this search.
         :param filters: The filters that are applied for this search.
         :param ordering: Sort the results by this ordering (or use default elastic ordering otherwise)
         :param page: The page index of the results
@@ -188,10 +186,6 @@ class ElasticSearchApiClient:
             body["query"]["bool"]["must"] += [query_string]
 
         indices = self.parse_index_language(self, filters)
-
-        default_filters = self.parse_filters(default_filters)
-        if default_filters:
-            body["query"]["bool"]["must"] += [default_filters]
 
         if drilldown_names:
             body["aggs"] = self.parse_aggregations(drilldown_names, filters)

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -142,15 +142,7 @@ class ElasticSearchApiClient:
         search_results["records"] = []
         return search_results
 
-    def search(
-            self,
-            search_text: list,
-            drilldown_names=None,
-            filters=None,
-            ordering=None,
-            page=1,
-            page_size=5
-            ):
+    def search(self, search_text: list, drilldown_names=None, filters=None, ordering=None, page=1, page_size=5):
         """
         Build and send a query to elasticsearch and parse it before returning.
         :param search_text: A list of strings to search for.


### PR DESCRIPTION
Filters act like OR in their own category, otherwise like AND.

How:

- Build an initial result set in elasticsearch applying only the default filters
- Create aggregations, each aggregation uses all the filters except the filters for their own category
- Apply all filters to the result set using post_filter

Also the selected filters are always displayed on top and sorted by count. The API now returns 0 by default instead of null for the count.