### PR TITLE
Fix community navigation

### DIFF
--- a/portal/src/pages/community.vue
+++ b/portal/src/pages/community.vue
@@ -25,15 +25,6 @@
             </Collections>
             <Spinner v-if="community_collections_loading" />
           </div>
-          <Materials
-            v-show="false"
-            :materials="materials"
-            class="community__materials"
-          >
-            <template slot="header-info">
-              <h2>{{ $t('Newest-open-learning-material') }}</h2>
-            </template>
-          </Materials>
 
           <template>
             <div v-show="false" class="community__row">
@@ -58,7 +49,6 @@ import InfoBlock from '~/components/InfoBlock'
 import Themes from '~/components/Themes'
 import Disciplines from '~/components/Disciplines'
 import Collections from '~/components/Collections'
-import Materials from '~/components/Materials'
 import Spinner from '~/components/Spinner'
 import Error from '~/components/error'
 import _ from 'lodash'
@@ -70,7 +60,6 @@ export default {
     Themes,
     Disciplines,
     Collections,
-    Materials,
     Spinner,
     InfoBlock
   },
@@ -87,8 +76,6 @@ export default {
       'community_disciplines',
       'community_themes',
       'community_collections_loading',
-      'materials',
-      'materials_loading',
       'user'
     ]),
     community_collections() {
@@ -127,10 +114,6 @@ export default {
     this.$store.dispatch('getCommunityThemes', community)
     this.$store.dispatch('getCommunityDisciplines', community)
     this.$store.dispatch('getCommunityCollections', community)
-    this.$store.dispatch('searchMaterials', {
-      page_size: 4,
-      search_text: ''
-    })
   }
 }
 </script>

--- a/portal/src/store/modules/materials.js
+++ b/portal/src/store/modules/materials.js
@@ -11,16 +11,17 @@ import axios from '~/axios'
 const $log = injector.get('$log')
 
 function generateSearchParams(search) {
-  const filters = Object.keys(search.filters).map(key => {
-    return { external_id: key, items: search.filters[key] }
+  const { search_text = '', filters = {} } = search
+  const filterArray = Object.keys(filters).map(key => {
+    return { external_id: key, items: filters[key] }
   })
 
-  const searchText = search.search_text.split(/\s+/).filter(x => x !== '')
+  const splittedSearchText = search_text.split(/\s+/).filter(x => x !== '')
 
   return {
     ...search,
-    search_text: searchText,
-    filters
+    search_text: splittedSearchText,
+    filters: filterArray
   }
 }
 


### PR DESCRIPTION
Fixes the bug Jelmer describes. When navigation to communities and clicking on a community the materials are greyed-out. This is because the search-query fails, because `Object.keys` was applied on `undefined`. Not all search queries contain filters.
Now when generating the search query, the filters will default to an empty object.

Also removed the search for materials query from the communities page as it was hidden anyway.