### PR TITLE
Remove author when searching

### DIFF
--- a/portal/src/App.vue
+++ b/portal/src/App.vue
@@ -35,13 +35,6 @@ export default {
       setLanguage(newLocale)
     }
   },
-  created() {
-    if (typeof window !== 'undefined') {
-      window.app = this
-    }
-    this.$store.dispatch('getFilterCategories')
-  },
-
   mounted() {
     this.$store.dispatch('getThemes')
   }

--- a/portal/src/components/InfoBlock/InfoBlock.js
+++ b/portal/src/components/InfoBlock/InfoBlock.js
@@ -1,7 +1,3 @@
-import { mapGetters } from 'vuex'
-import Search from '~/components/Search'
-import Materials from '~/components/Materials'
-
 export default {
   props: {
     title: '',
@@ -9,19 +5,5 @@ export default {
     logo_src: { default: '/images/pictures/image_home.jpg', type: String },
     featured_image: '',
     website_url: ''
-  },
-  components: {
-    Search,
-    Materials
-  },
-  computed: {
-    ...mapGetters(['materials'])
-  },
-  mounted() {
-    this.$store.dispatch('searchMaterials', {
-      page_size: 4,
-      search_text: '',
-      return_filters: false
-    })
   }
 }

--- a/portal/src/components/Materials/Materials.component.html
+++ b/portal/src/components/Materials/Materials.component.html
@@ -88,7 +88,7 @@
                   v-if="index < 2"
                   class="materials__item_educationallevel"
                 >
-                  {{ educationallevel }}
+                  {{ educationallevel[$i18n.locale] }}
                   <span v-if="material.educationallevels.length > 1 && index < material.educationallevels.length - 1">,</span>
                 </span>
                 {{ material.educationallevels.length < 3 ? '' : '...' }}

--- a/portal/src/components/Materials/Materials.component.html
+++ b/portal/src/components/Materials/Materials.component.html
@@ -88,7 +88,8 @@
                   v-if="index < 2"
                   class="materials__item_educationallevel"
                 >
-                  {{getTitleTranslation(educationallevel, $i18n.locale) }}<span v-if="material.educationallevels.length > 1 && index < material.educationallevels.length - 1">,</span>
+                  {{ educationallevel }}
+                  <span v-if="material.educationallevels.length > 1 && index < material.educationallevels.length - 1">,</span>
                 </span>
                 {{ material.educationallevels.length < 3 ? '' : '...' }}
               </div>

--- a/portal/src/components/Materials/Materials.component.js
+++ b/portal/src/components/Materials/Materials.component.js
@@ -36,9 +36,6 @@ export default {
   components: {
     StarRating
   },
-  mounted() {
-    this.$store.dispatch('getFilterCategories')
-  },
   data() {
     return {
       selected_materials: this.value || []
@@ -91,54 +88,22 @@ export default {
     current_loading() {
       return this.materials_loading || this.loading
     },
-    /**
-     * Extend to the material fields "disciplines" & "educationallevels"
-     * @returns {*}
-     */
     extended_materials() {
-      const { materials, disciplines, selected_materials } = this
-      let arrMaterials
-      if (materials && disciplines) {
-        if (materials.records) {
-          arrMaterials = materials.records
-        } else {
-          arrMaterials = materials
-        }
-        let self = this
+      const { materials, selected_materials } = this
+      if (materials) {
+        const arrMaterials = materials.records ? materials.records : materials
+
         return arrMaterials.map(material => {
-          return Object.assign(
-            {
-              selected: selected_materials.indexOf(material.external_id) !== -1
-            },
-            material,
-            {
-              disciplines: material.disciplines.reduce((prev, id) => {
-                const item = disciplines[id]
+          const description =
+            material.description && material.description.length > 200
+              ? material.description.slice(0, 200) + '...'
+              : material.description
 
-                if (item) {
-                  prev.push(item)
-                }
-
-                return prev
-              }, []),
-              description:
-                material.description && material.description.length > 200
-                  ? material.description.slice(0, 200) + '...'
-                  : material.description,
-              educationallevels: material.educationallevels.reduce(
-                (prev, id) => {
-                  const item = self.$store.getters.getCategoryById(id)
-
-                  if (item) {
-                    prev.push(item)
-                  }
-
-                  return prev
-                },
-                []
-              )
-            }
-          )
+          return {
+            ...material,
+            selected: selected_materials.indexOf(material.external_id) !== -1,
+            description
+          }
         })
       }
 

--- a/portal/src/components/Materials/Materials.component.js
+++ b/portal/src/components/Materials/Materials.component.js
@@ -81,7 +81,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['disciplines', 'materials_loading']),
+    ...mapGetters(['materials_loading']),
     selectMaterialClass() {
       return this.selectFor === 'delete' ? 'select-delete' : 'select-neutral'
     },

--- a/portal/src/components/Materials/Sidebar/Sidebar.component.html
+++ b/portal/src/components/Materials/Sidebar/Sidebar.component.html
@@ -5,9 +5,11 @@
         <h4>{{ $t('Discipline') }}</h4>
         <div>{{ extended_material.disciplineTitles }}</div>
       </template>
-      <template v-if="material.educationallevelsTitles" class="materials__item_educationallevels">
+      <template v-if="material.educationallevels" class="materials__item_educationallevels">
         <h4>{{ $t('Learning-levels') }}</h4>
-        <div v-html="extended_material.educationallevelsTitles"></div>
+        <div v-for="educational_level in material.educationallevels">
+          {{ educational_level[$i18n.locale] }}
+        </div>
       </template>
       <!--<h4>Soort materiaal</h4>-->
       <!--Video-->

--- a/portal/src/components/Materials/Sidebar/Sidebar.component.js
+++ b/portal/src/components/Materials/Sidebar/Sidebar.component.js
@@ -285,7 +285,7 @@ export default {
       'disciplines'
     ]),
     /**
-     * Extend to the material fields "disciplines" & "educationallevels"
+     * Extend to the material fields "disciplines"
      * @returns {*}
      */
     extended_material() {
@@ -306,25 +306,6 @@ export default {
           return this.getTitleTranslation(disciplineObj, self.$i18n.locale)
         })
         material.disciplineTitles = disciplineTitles.join(', ')
-      }
-
-      if (material.educationallevels.length) {
-        let educationallevelsTitles = _.map(
-          material.educationallevels,
-          level => {
-            let levelObj = _.isObject(level)
-              ? level
-              : self.$store.getters.getCategoryById(level)
-            if (_.isNil(levelObj)) {
-              return
-            }
-            return this.getTitleTranslation(levelObj, self.$i18n.locale)
-          }
-        )
-        material.educationallevelsTitles = _.without(
-          educationallevelsTitles,
-          undefined
-        ).join('<br/>')
       }
 
       return material

--- a/portal/src/components/Search/Search.component.html
+++ b/portal/src/components/Search/Search.component.html
@@ -1,4 +1,4 @@
-<section class="search" :class="{'search--hide-categories': !displayEducationalLevelSelect}">
+<section class="search" :class="{'search--hide-categories': !selectOptions || selectOptions.options.length === 0}">
   <form
     action="/materials/search/"
     @submit.prevent="onSubmit"
@@ -14,36 +14,35 @@
           @selected="onSelectSuggestion"
           >
         </vue-autosuggest>
-        <div class="search__chooser search__select" v-if="displayEducationalLevelSelect">
+        <div class="search__chooser search__select" v-if="selectOptions && selectOptions.options.length > 0">
           <select
             name="categories"
-            @change="changeFilterCategory"
-            v-if="educationalLevelCategory"
-          >
-            <option value="" hidden>{{ educationalLevelCategory.name }}</option>
+            @change="changeSelectedOption"
+            >
+            <option value="" hidden>{{ selectOptions.name }}</option>
             <option
-              v-for="category in educationalLevelCategory.children"
+              v-for="category in selectOptions.options"
               :value="category.external_id"
-            >{{titleTranslation(category) }}</option>
+              >{{titleTranslation(category) }}</option>
           </select>
         </div>
         <button
           class="button"
           type="submit"
-        >
+          >
           {{ $t('Search') }}
         </button>
       </div>
     </div>
-    <div class="search__themes" v-if="displayMaterialTypeFilter">
+    <div class="search__themes" v-if="checkboxOptions && checkboxOptions.options.length > 0">
       <h4 class="search__themes_title">{{ $t('Filter-search-results') }}</h4>
-      <ul if="materialTypeCategory" class="search__themes_items">
-        <li v-for="item in materialTypeCategory.children" v-if="!item.is_hidden" class="search__themes_item">
+      <ul class="search__themes_items">
+        <li v-for="item in checkboxOptions.options" v-if="!item.is_hidden" class="search__themes_item">
           <input
             type="checkbox"
             :id="item.external_id"
             :value="item.external_id"
-            v-model="item.selected"
+            @change="changeCheckboxOption"
             name="search_category"
           >
           <label :for="item.external_id"> {{titleTranslation(item) }}</label>

--- a/portal/src/components/Search/Search.component.html
+++ b/portal/src/components/Search/Search.component.html
@@ -15,21 +15,18 @@
           >
         </vue-autosuggest>
         <div class="search__chooser search__select" v-if="selectOptions && selectOptions.options.length > 0">
-          <select
-            name="categories"
-            @change="changeSelectedOption"
-            >
+          <select name="categories" @change="changeSelectedOption">
             <option value="" hidden>{{ selectOptions.name }}</option>
             <option
               v-for="category in selectOptions.options"
               :value="category.external_id"
-              >{{titleTranslation(category) }}</option>
+            >{{titleTranslation(category) }}</option>
           </select>
         </div>
         <button
           class="button"
           type="submit"
-          >
+        >
           {{ $t('Search') }}
         </button>
       </div>

--- a/portal/src/components/Search/Search.component.js
+++ b/portal/src/components/Search/Search.component.js
@@ -33,10 +33,6 @@ export default {
       })
     }
   },
-  mounted() {
-    // TODO: this should be somewhere else..
-    this.$store.dispatch('getFilterCategories')
-  },
   data() {
     return {
       searchText: this.value.search_text,

--- a/portal/src/components/Search/Search.component.js
+++ b/portal/src/components/Search/Search.component.js
@@ -35,10 +35,7 @@ export default {
   },
   mounted() {
     // TODO: this should be somewhere else..
-    this.$store.dispatch('getFilterCategories').then(() => {
-      const filters = this.$store.getters.getFiltersFromQuery(this.$route.query)
-      this.$store.commit('SETUP_FILTER_CATEGORIES', filters)
-    })
+    this.$store.dispatch('getFilterCategories')
   },
   data() {
     return {

--- a/portal/src/components/Search/Search.component.js
+++ b/portal/src/components/Search/Search.component.js
@@ -62,7 +62,8 @@ export default {
       this.suggestions = [{ data }]
     }, 350),
     onSelectSuggestion(result) {
-      this.$emit('input', result.item)
+      const text = result ? result.item : this.searchText
+      this.$emit('input', text)
       this.$emit('onSearch')
     },
     onSubmit() {

--- a/portal/src/components/_helpers.js
+++ b/portal/src/components/_helpers.js
@@ -1,8 +1,10 @@
+import i18n from '~/i18n'
+
 export const generateSearchMaterialsQuery = function(
   data = { filters: {}, search_text: '' },
   name = 'materials-search'
 ) {
-  name += '___' + this.$i18n.locale
+  name += '___' + i18n.locale
 
   return {
     name: name,

--- a/portal/src/pages/index.vue
+++ b/portal/src/pages/index.vue
@@ -173,7 +173,9 @@ export default {
       this.$router.push(
         generateSearchMaterialsQuery({
           search_text: this.searchText,
-          filters: this.filters
+          filters: this.filters,
+          page_size: 10,
+          page: 1
         })
       )
     }

--- a/portal/src/pages/index.vue
+++ b/portal/src/pages/index.vue
@@ -115,6 +115,7 @@ export default {
     this.$store.dispatch('getMaterials', { page_size: 4 })
     this.$store.dispatch('getCommunities', { params: { page_size: 3 } })
     this.$store.dispatch('getStatistic')
+    this.$store.dispatch('getFilterCategories')
   }
 }
 </script>

--- a/portal/src/pages/index.vue
+++ b/portal/src/pages/index.vue
@@ -11,7 +11,7 @@
           <div class="main__info_block">
             <div class="bg" />
             <h2 class="main__info_title">
-              <span v-if="statistic">{{ contedNumber }} </span
+              <span v-if="statistic">{{ countedNumber }} </span
               >{{ $t('open-learning-materials-from-higher-education') }}
             </h2>
             <ul class="main__info_items">
@@ -105,7 +105,7 @@ export default {
      * Get formatted 'number_of_views'
      * @returns String
      */
-    contedNumber() {
+    countedNumber() {
       return numeral(this.statistic.value)
         .format('0,0')
         .replace(',', '.')

--- a/portal/src/pages/search.vue
+++ b/portal/src/pages/search.vue
@@ -16,7 +16,12 @@
               class="search__info_bg"
             />
           </div>
-          <Search v-if="search" v-model="search" class="search__info_search" />
+          <Search
+            v-if="search"
+            @onSearch="searchMaterials"
+            v-model="search.search_text"
+            class="search__info_search"
+          />
         </div>
       </div>
 
@@ -128,7 +133,16 @@ export default {
     this.$store.dispatch('searchMaterials', urlInfo.search)
   },
   methods: {
-    generateSearchMaterialsQuery,
+    searchMaterials() {
+      this.search = {
+        search_text: this.search.search_text,
+        filters: {},
+        page_size: 10,
+        page: 1
+      }
+      this.$store.dispatch('searchMaterials', this.search)
+      this.$router.push(generateSearchMaterialsQuery(this.search))
+    },
     loadMore() {
       const { search, materials } = this
       if (materials && search) {
@@ -166,7 +180,7 @@ export default {
       }
       this.search.page = 1
       this.$store.dispatch('searchMaterials', Object.assign({}, this.search))
-      this.$router.push(this.generateSearchMaterialsQuery(this.search))
+      this.$router.push(generateSearchMaterialsQuery(this.search))
     },
     getFilterCategories() {
       return this.materials ? this.materials.filter_categories : []

--- a/portal/src/pages/search.vue
+++ b/portal/src/pages/search.vue
@@ -101,16 +101,9 @@ export default {
       search: {
         filters: {}
       },
-      isShow: false,
-      publisherDateExternalId: 'lom.lifecycle.contribute.publisherdate',
-      dates_range: {
-        start_date: null,
-        end_date: null
-      },
       formData: {
         name: null
       },
-      items: [{ title: this.$t('Home'), url: this.localePath('index') }],
       sort_order: 'relevance',
       sort_order_options: [
         { value: 'relevance' },
@@ -127,19 +120,10 @@ export default {
       if (search && !this.materials_loading) {
         this.$store.dispatch('searchMaterials', search)
       }
-    },
-    dates_range(dates) {
-      const { filters } = this.search
-      filters[this.publisherDateExternalId] = [
-        dates.start_date || null,
-        dates.end_date || null
-      ]
-      this.search = { ...this.search, filters }
     }
   },
   mounted() {
     const urlInfo = parseSearchMaterialsQuery(this.$route.query)
-    this.dates_range = urlInfo.dateRange
     this.search = urlInfo.search
     this.$store.dispatch('searchMaterials', urlInfo.search)
   },

--- a/portal/src/pages/search.vue
+++ b/portal/src/pages/search.vue
@@ -18,9 +18,9 @@
           </div>
           <Search
             v-if="search"
-            @onSearch="searchMaterials"
             v-model="search.search_text"
             class="search__info_search"
+            @onSearch="searchMaterials"
           />
         </div>
       </div>

--- a/portal/src/store/modules/filter-categories.js
+++ b/portal/src/store/modules/filter-categories.js
@@ -1,10 +1,7 @@
 import _ from 'lodash'
-import injector from 'vue-inject'
 import { parseSearchMaterialsQuery } from '~/components/_helpers'
 import axios from '~/axios'
 import router from '~/router'
-
-const $log = injector.get('$log')
 
 const PUBLISHER_DATE_ID = 'lom.lifecycle.contribute.publisherdate'
 
@@ -83,13 +80,6 @@ function loadCategoryFilters(items, selected, dates, opened, showAlls, parent) {
   })
   return _.some(items, item => {
     return item.selected
-  })
-}
-
-function setChildrenSelected(children, value) {
-  _.forEach(children, child => {
-    child.selected = value
-    setChildrenSelected(child.children, value)
   })
 }
 
@@ -187,43 +177,6 @@ export default {
     },
     SET_FILTER_CATEGORIES_LOADING(state, payload) {
       state.filter_categories_loading = payload
-    },
-    SETUP_FILTER_CATEGORIES(state, data) {
-      if (_.isNil(state.filter_categories)) {
-        $log.info('Unable to setup filter categories due to missing categories')
-        return
-      }
-      let openFilters = _.filter(state.filter_categories.results, item => {
-        return item.isOpen
-      })
-      let openFilterIds = _.map(openFilters, item => {
-        return item.id
-      })
-      let showAllFilters = _.filter(state.filter_categories.results, item => {
-        return item.showAll
-      })
-      let showAllFilterIds = _.map(showAllFilters, item => {
-        return item.id
-      })
-      state.filter_categories.results = _.cloneDeep(
-        state.filter_categories.defaults
-      )
-      loadCategoryFilters(
-        state.filter_categories.results,
-        data.selected,
-        data.dateRange,
-        openFilterIds,
-        showAllFilterIds
-      )
-      this.commit('SET_FILTER_CATEGORIES', state.filter_categories)
-    },
-    SET_FILTER_SELECTED(state, categoryId) {
-      let category = state.byCategoryId[categoryId]
-      if (!_.isNil(category)) {
-        setChildrenSelected(category.children, category.selected)
-      }
-      state.filter_categories = _.cloneDeep(state.filter_categories)
-      this.commit('SET_FILTER_CATEGORIES', state.filter_categories)
     }
   }
 }

--- a/service/surf/apps/materials/utils.py
+++ b/service/surf/apps/materials/utils.py
@@ -84,8 +84,9 @@ def add_extra_parameters_to_materials(user, materials):
         else:
             m["view_count"] = m["applaud_count"] = m["avg_star_rating"] = m["count_star_rating"] = 0
 
-        level_records = list(filter(lambda x: x.name in m["educationallevels"], educational_level_filters))
-        m["educationallevels"] = ({"en": x.title_translations.en, "nl": x.title_translations.nl} for x in level_records)
+        level_items = list(filter(lambda item: item.name in m["educationallevels"], educational_level_filters))
+        m["educationallevels"] = ({"en": level.title_translations.en, "nl": level.title_translations.nl}
+                                  for level in level_items)
 
         communities = Community.objects.filter(
             collections__materials__external_id=m["external_id"])


### PR DESCRIPTION
Clears filters when searching for another search text. This is done by removing a lot of logic out of the `Search` component and moving it to a higher level. Now the component simply has a string as `v-model` containing the search-text. Instead of a whole search object which is mutated at a lot of places. Also the actual search action is moved out of the search box component and put a level higher. This way the search logic can easier differ between pages.

The `getFilterCategories` action was dispatched at a lot of places. Also at `App.vue`, so on every app load the filter categories were fetched. I removed this and only fetch it on the homepage for the select and checkbox filters for now (and it is still on the theme page, I don't want to touch that for now).

