### PR TITLE
Fix applaud align

### DIFF
--- a/portal/src/components/Materials/Materials.component.less
+++ b/portal/src/components/Materials/Materials.component.less
@@ -163,15 +163,11 @@
       height: 25px;
       border-radius: 4px;
       color: #fff;
-      display: inline-flex;
-      font-family: @second-font;
       font-size: 16px;
       font-weight: bold;
-      font-style: normal;
-      font-stretch: normal;
-      line-height: 22px;
       min-width: 58px;
       padding-left: 23px;
+      font-size: 1.1em;
     }
 
     &_external_link {


### PR DESCRIPTION
There seems to be an issue with the `Nunito` font. Somehow it renders with another line height on Firefox than Chrome. I changed the font to the primary font, I don't think anyone will notice it and it fixes the issue. Couldn't figure out how to align the `Nunito` font properly.