### PR TITLE
Start a fresh selenium driver and clear connections on every test

### DIFF
--- a/service/e2e_tests/base.py
+++ b/service/e2e_tests/base.py
@@ -23,15 +23,6 @@ class BaseTestCase(StaticLiveServerTestCase):
     def tearDown(cls):
         super().tearDown()
         cls.selenium.quit()
-        # FIXME: Ugly hack to kill open connections. Somehow it doesn't work on Github Actions otherwise.
-        # There seems to be a running query for the filter tree which doesn't terminate in time.
-        with connection.cursor() as c:
-            c.execute("""
-                SELECT pg_terminate_backend(pg_stat_activity.pid)
-                FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = 'test_edushare'
-                    AND pid <> pg_backend_pid();
-                """)
 
 
 @override_settings(ELASTICSEARCH_NL_INDEX="test-nl", ELASTICSEARCH_EN_INDEX="test-en")

--- a/service/e2e_tests/base.py
+++ b/service/e2e_tests/base.py
@@ -11,9 +11,8 @@ from elasticsearch import Elasticsearch
 class BaseTestCase(StaticLiveServerTestCase):
     fixtures = ['locales', 'privacy_statements']
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(cls):
+        super().setUp()
         chrome_options = Options()
         chrome_options.add_argument("--headless")
         chrome_options.add_argument("window-size=1920,1080")
@@ -21,10 +20,9 @@ class BaseTestCase(StaticLiveServerTestCase):
         cls.selenium = WebDriver(options=chrome_options)
         cls.selenium.implicitly_wait(10)
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(cls):
+        super().tearDown()
         cls.selenium.quit()
-        super().tearDownClass()
         # FIXME: Ugly hack to kill open connections. Somehow it doesn't work on Github Actions otherwise.
         # There seems to be a running query for the filter tree which doesn't terminate in time.
         with connection.cursor() as c:

--- a/service/e2e_tests/base.py
+++ b/service/e2e_tests/base.py
@@ -1,7 +1,6 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.chrome.options import Options
-from django.db import connection
 from django.conf import settings
 from django.test import override_settings
 

--- a/service/e2e_tests/test_collection_materials.py
+++ b/service/e2e_tests/test_collection_materials.py
@@ -19,6 +19,7 @@ class TestCollectionMaterials(ElasticSearchTestCase):
         )
 
     def setUp(self):
+        super().setUp()
         self.user = UserFactory.create()
         self.community = CommunityFactory.create()
         TeamFactory.create(user=self.user, community=self.community)

--- a/service/e2e_tests/test_collections.py
+++ b/service/e2e_tests/test_collections.py
@@ -8,6 +8,7 @@ from e2e_tests.helpers import login, replace_content
 
 class TestCollections(BaseTestCase):
     def setUp(self):
+        super().setUp()
         self.user = UserFactory.create()
         self.community = CommunityFactory.create()
         TeamFactory.create(user=self.user, community=self.community)

--- a/service/e2e_tests/test_communities.py
+++ b/service/e2e_tests/test_communities.py
@@ -11,6 +11,7 @@ from surf.statusenums import PublishStatus
 
 class TestCommunities(BaseTestCase):
     def setUp(cls):
+        super().setUp()
         cls.user = UserFactory.create()
         login(cls, cls.user)
 


### PR DESCRIPTION
Prevents tests failing because connections are still open and causing deadlocks. Also prevents sessions from persisting between tests.