### PR TITLE
Fako/celery improvements 3

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,3 +1,12 @@
 import os
+from service.package import PACKAGE as SERVICE_PACKAGE
+from harvester.package import PACKAGE as HARVESTER_PACKAGE
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+REPOSITORY = "017973353230.dkr.ecr.eu-central-1.amazonaws.com"
+
+TARGETS = {
+    "service": SERVICE_PACKAGE,
+    "harvester": HARVESTER_PACKAGE
+}

--- a/commands/aws/ecs.py
+++ b/commands/aws/ecs.py
@@ -1,0 +1,99 @@
+import os
+import json
+from invoke import Exit
+import boto3
+
+from commands import TARGETS, REPOSITORY
+from environments.surfpol import MODE
+
+
+def register_task_definition(ecs_client, task_role_arn, target, mode, version, cpu, memory):
+
+    # Validating input
+    if target not in TARGETS:
+        raise Exit(f"Unknown target: {target}", code=1)
+    if mode != MODE:
+        raise Exit(f"Expected mode to match APPLICATION_MODE value but found: {mode}", code=1)
+
+    # Load data
+    target_info = TARGETS[target]
+    version = version or target_info["version"]
+
+    # Read the service AWS container definition and replace some variables with actual values
+    print(f"Reading container definitions for: {target_info['name']}")
+    with open(os.path.join(target, "aws-container-definitions.json")) as container_definitions_file:
+        container_definitions_json = container_definitions_file.read()
+        container_variables = {
+            "REPOSITORY": REPOSITORY,
+            "mode": mode,
+            "version": version
+        }
+        for name, value in container_variables.items():
+            container_definitions_json = container_definitions_json.replace(f"${{{name}}}", value)
+        container_definitions = json.loads(container_definitions_json)
+
+    # Now we push the task definition to AWS
+    print("Setting up task definition")
+    response = ecs_client.register_task_definition(
+        family=f"{target_info['name']}",
+        taskRoleArn=task_role_arn,
+        executionRoleArn=task_role_arn,
+        networkMode="awsvpc",
+        cpu=cpu,
+        memory=memory,
+        containerDefinitions=container_definitions
+    )
+    # And we update the service with new task definition
+    task_definition = response["taskDefinition"]
+    return target_info['name'], task_definition["taskDefinitionArn"]
+
+
+def run_task(ctx, target, mode, command, environment=None, version=None):
+    """
+    Executes any (Django) command on container cluster for development, acceptance or production environment on AWS
+    """
+    if mode != MODE:
+        raise Exit(f"Expected mode to match APPLICATION_MODE value but found: {mode}", code=1)
+
+    environment = environment or []
+
+    # Setup the AWS SDK
+    print(f"Starting AWS session for: {mode}")
+    session = boto3.Session(profile_name=ctx.config.aws.profile_name)
+    ecs_client = session.client('ecs', region_name='eu-central-1')
+
+    target_info = TARGETS[target]
+    target_name, task_definition_arn = register_task_definition(
+        ecs_client,
+        ctx.config.aws.superuser_task_role_arn,
+        target,
+        mode,
+        version,
+        target_info["cpu"],
+        target_info["memory"]
+    )
+
+    print(f"Target/mode: {target}/{mode}")
+    print(f"Executing: {command}")
+    ecs_client.run_task(
+        cluster=ctx.config.aws.cluster_arn,
+        taskDefinition=task_definition_arn,
+        launchType="FARGATE",
+        overrides={
+            "containerOverrides": [{
+                "name": f"{target_info['name']}-container",
+                "command": command,
+                "environment": environment
+            }]
+        },
+        networkConfiguration={
+            "awsvpcConfiguration": {
+                "subnets": [ctx.config.aws.private_subnet_id],
+                "securityGroups": [
+                    ctx.config.aws.rds_security_group_id,
+                    ctx.config.aws.default_security_group_id
+
+                ]
+            }
+        },
+    )

--- a/harvester/core/background.py
+++ b/harvester/core/background.py
@@ -16,5 +16,5 @@ def health_check():
 
 @app.task(name="import_dataset")
 def celery_import_dataset(dataset, role="primary"):
-    call_command("load_harvester_data", dataset, default_aws_credentials=True)
+    call_command("load_harvester_data", dataset)
     call_command("push_es_index", dataset=dataset, recreate=True)

--- a/harvester/core/background.py
+++ b/harvester/core/background.py
@@ -16,6 +16,5 @@ def health_check():
 
 @app.task(name="import_dataset")
 def celery_import_dataset(dataset, role="primary"):
-    skip_download = role != "primary"  # replica environments should not try to download data
-    call_command("load_harvester_data", dataset, default_aws_credentials=True, skip_download=skip_download)
+    call_command("load_harvester_data", dataset, default_aws_credentials=True)
     call_command("push_es_index", dataset=dataset, recreate=True)

--- a/harvester/core/management/commands/import_dataset.py
+++ b/harvester/core/management/commands/import_dataset.py
@@ -1,0 +1,16 @@
+from django.core.management import base
+
+from core.management.base import HarvesterCommand
+from core.background import celery_import_dataset
+
+
+class Command(base.LabelCommand, HarvesterCommand):
+    """
+    A command that calls the import_dataset background task
+    Normally this background task runs once a day, but we may want to trigger this manually as well,
+    especially during development on AWS
+    """
+
+    def handle_label(self, dataset, **options):
+        self.info(f"Calling import_dataset outside of schedule for: {dataset}")
+        celery_import_dataset(dataset)

--- a/harvester/core/management/commands/load_harvester_data.py
+++ b/harvester/core/management/commands/load_harvester_data.py
@@ -24,7 +24,6 @@ class Command(base.LabelCommand, HarvesterCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument('-s', '--skip-download', action="store_true")
-        parser.add_argument('-d', '--default-aws-credentials', action="store_true")
 
     def load_resources(self):
         for resource_model in self.resources:
@@ -39,7 +38,6 @@ class Command(base.LabelCommand, HarvesterCommand):
 
     def handle_label(self, dataset_label, **options):
 
-        default_aws_credentials = options["default_aws_credentials"]
         skip_download = options["skip_download"]
 
         # Delete old datasets
@@ -58,9 +56,8 @@ class Command(base.LabelCommand, HarvesterCommand):
         if not len(dump_files) and not skip_download:
             self.info(f"Downloading dump file for: {dataset_label}")
             ctx = Context(environment)
-            profile_declaration = "" if default_aws_credentials else "AWS_DEFAULT_PROFILE=pol-dev"
             harvester_data_bucket = "s3://edushare-data/datasets/harvester"
-            ctx.run(f"{profile_declaration} aws s3 sync {harvester_data_bucket} {settings.DATAGROWTH_DATA_DIR}")
+            ctx.run(f"aws s3 sync {harvester_data_bucket} {settings.DATAGROWTH_DATA_DIR}")
         self.info(f"Importing dataset: {dataset_label}")
         for entry in os.scandir(get_dumps_path(Dataset)):
             if entry.is_file() and entry.name.startswith(dataset_label):

--- a/harvester/package.py
+++ b/harvester/package.py
@@ -1,5 +1,5 @@
 PACKAGE = {
-    "version": "1.2.0",
+    "version": "1.2.2",
     "name": "harvester",
     "cpu": "1024",
     "memory": "2048"


### PR DESCRIPTION
Refactor van migrate tasks op AWS, zodat we meerdere soorten tasks kunnen uitvoeren waaronder "import dataset" voor harvester

Ik probeerde in vorige PR's om gebruik van resources zoveel mogelijk te beperken, maar voor nu toch maar even full blown. Alles download voor zichzelf. In de toekomst willen we wel graag een andere setup, waarbij er 1 primary is en de rest replica. Dat is op verzoek van Kennisnet (organisatie achter Edurep). Let's cross that bridge when we get there. Voor nu connect AWS helemaal niet met Edurep, dat doet legacy harvester voor ons.