### PR TITLE
Sentry reverse proxy

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
     build:
       dockerfile: "service/Dockerfile"
       context: .
-    command: uwsgi --ini uwsgi.ini --py-autoreload=3 --honour-stdin
+    command: /usr/bin/supervisord
     stdin_open: true
     tty: true
     environment:
@@ -18,7 +18,7 @@ services:
       - POL_DJANGO_DEBUG=${POL_DJANGO_DEBUG}
       - POL_DJANGO_POSTGRES_USER=${POL_DJANGO_POSTGRES_USER}
     ports:
-      - "127.0.0.1:8000:8080"
+      - "127.0.0.1:8000:80"
     volumes:
       - ./service:/usr/src/app
       - ./media:/usr/src/media

--- a/portal/src/main.js
+++ b/portal/src/main.js
@@ -3,7 +3,7 @@ import * as Integrations from '@sentry/integrations'
 
 if (process.env.VUE_APP_USE_SENTRY) {
   Sentry.init({
-    dsn: 'https://21fab3e788584cbe999f20ea1bb7e2df@sentry.io/2964956',
+    dsn: `${window.location.protocol}//21fab3e788584cbe999f20ea1bb7e2df@${window.location.host}/sentry/2964956`,
     integrations: [new Integrations.CaptureConsole()],
     beforeSend(event) {
       if (event.user) {

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -29,7 +29,11 @@ RUN npm install && npm run build
 
 FROM python:3.6-stretch
 
-RUN apt-get update && apt-get install -y less vim build-essential gettext
+RUN apt-get update && apt-get install -y less vim build-essential gettext nginx supervisor
+
+# Setup nginx
+COPY service/search-portal.conf /etc/nginx/conf.d/
+RUN rm /etc/nginx/sites-enabled/default
 
 # Create the app environment
 RUN mkdir -p /usr/src/app
@@ -78,8 +82,8 @@ RUN export APPLICATION_MODE=localhost && python manage.py collectstatic --noinpu
 # There are some translations of Django packages that we want to use
 RUN export APPLICATION_MODE=localhost && python manage.py compilemessages
 
-# The default command is to start a uWSGI server
-CMD ["uwsgi", "--ini", "/usr/src/app/uwsgi.ini"]
+USER root:root
+CMD ["/usr/bin/supervisord"]
 
-# EXPOSE port 8080 to allow communication to/from server
-EXPOSE 8080
+# EXPOSE port 80 to allow communication to/from server
+EXPOSE 80

--- a/service/aws-container-definitions.json
+++ b/service/aws-container-definitions.json
@@ -6,9 +6,9 @@
         "essential": true,
         "portMappings": [
             {
-                "hostPort": 8080,
+                "hostPort": 80,
                 "protocol": "tcp",
-                "containerPort": 8080
+                "containerPort": 80
             }
         ],
         "environment": [

--- a/service/search-portal.conf
+++ b/service/search-portal.conf
@@ -1,0 +1,12 @@
+server {
+    listen      80 default_server;
+
+    location /sentry {
+        proxy_pass https://sentry.io/;
+    }
+
+    location / {
+        uwsgi_pass 127.0.0.1:3031;
+        include uwsgi_params;
+    }
+}

--- a/service/supervisord.conf
+++ b/service/supervisord.conf
@@ -1,0 +1,25 @@
+[supervisord]
+nodaemon=true
+pidfile=/tmp/supervisord.pid
+logfile=/dev/fd/1
+logfile_maxbytes=0
+
+[program:uwsgi]
+command=uwsgi --ini /usr/src/app/uwsgi.ini --py-autoreload=3 --honour-stdin --socket 127.0.0.1:3031
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+environment=HOME="/home/app",USER="app"
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+startretries=5
+numprocs=1
+startsecs=0
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/service/uwsgi.ini
+++ b/service/uwsgi.ini
@@ -1,5 +1,4 @@
 [uwsgi]
-http = 0.0.0.0:8080
 wsgi-file = surf/wsgi.py
 uid = app
 gid = app
@@ -9,8 +8,6 @@ threads = 1
 offload-threads = 2
 
 env = LANG=en_US.utf8
-
-;route-if=equal:${HTTP_X_FORWARDED_PROTO};http redirect-permanent:https://${HTTP_HOST}${REQUEST_URI}
 
 static-map = /images=/usr/src/static/portal/images
 static-expires = /images/.+ 3600


### PR DESCRIPTION
Adds a reverse proxy for sentry. Errors are now sent to `{HOST}/sentry`, instead of directly to sentry.io.
I wasn't able to do this in uWSGI, so I added nginx in front of uWSGI. Nginx either sends the traffic to sentry.io or uWSGI. I am not very familiar with uWSGI, but from what I've been reading it seems like nginx is preferred for production environments.

This also means the container does now expose port 80 instead of port 8080. When deploying the Fargate service has to be recreated, otherwise it does not deploy because it expects port 8080.

I tested it on the development environment and it works over there.

@fako , maybe you have a better idea. I will keep it open as a pull request, so you can decide whether you want to merge it like this 😉 .