### PR TITLE
Date relevance in elastic search query

### DIFF
--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -190,6 +190,14 @@ class ElasticSearchApiClient:
                 }
             }
             body["query"]["bool"]["must"] += [query_string]
+            body["query"]["bool"]["should"] = {
+                "distance_feature": {
+                    "field": "publisher_date",
+                    "pivot": "1095d",
+                    "origin": "now",
+                    "boost": 1.0
+                }
+            }
 
         indices = self.parse_index_language(self, filters)
 

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -193,9 +193,9 @@ class ElasticSearchApiClient:
             body["query"]["bool"]["should"] = {
                 "distance_feature": {
                     "field": "publisher_date",
-                    "pivot": "1095d",
+                    "pivot": "90d",
                     "origin": "now",
-                    "boost": 1.0
+                    "boost": 1.5
                 }
             }
 


### PR DESCRIPTION
I used this [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-distance-feature-query.html) to add recency of a publication into the search query mix.

Several params can be tweaked, namely pivot (distance from origin at which relevance scores receive half of the boost value) and boost (Floating point number used to multiply the relevance score of matching documents).

I used 3 years for pivot (1095 days) and 1.0 for boost (which is the default). We should tweak these values some more.