### PR TITLE
Make authors searchable in index

### DIFF
--- a/harvester/core/management/commands/push_es_index.py
+++ b/harvester/core/management/commands/push_es_index.py
@@ -19,7 +19,8 @@ class Command(HarvesterCommand):
         dataset = Dataset.objects.get(name=options["dataset"])
         recreate = options["recreate"]
         promote = options["promote"]
-        earliest_harvest = dataset.get_earliest_harvest_date() or datetime(year=1970, month=1, day=1, tzinfo=tz.tzutc())
+        begin_of_time = datetime(year=1970, month=1, day=1, tzinfo=tz.tzutc())
+        earliest_harvest = begin_of_time if recreate else dataset.get_earliest_harvest_date() or begin_of_time
 
         self.info(f"Upserting ES index for {dataset.name}")
         self.info(f"since:{earliest_harvest:%Y-%m-%d}, recreate:{recreate} and promote:{promote}")

--- a/harvester/core/management/commands/push_es_index.py
+++ b/harvester/core/management/commands/push_es_index.py
@@ -41,6 +41,8 @@ class Command(HarvesterCommand):
                     "configuration": ElasticIndex.get_index_config(lang)
                 }
             )
+            if recreate:
+                index.configuration = None  # gets recreated by the clean method below
             index.clean()
             index.push(docs, recreate=recreate)
             index.save()

--- a/harvester/core/models/search.py
+++ b/harvester/core/models/search.py
@@ -128,7 +128,13 @@ class ElasticIndex(models.Model):
                         'type': 'keyword'
                     },
                     'authors': {
-                        'type': 'keyword'
+                        'type': 'text',
+                        'fields': {
+                            'keyword': {
+                                'type': 'keyword',
+                                'ignore_above': 256
+                            }
+                        }
                     },
                     'publishers': {
                         'type': 'keyword'

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -314,7 +314,7 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         stdout = out.getvalue().split("\n")
         results = [rsl for rsl in stdout if rsl]
         self.assertIn(
-            "since:2020-02-10, recreate:True and promote:False",
+            "since:1970-01-01, recreate:True and promote:False",
             results,
             "Expected command to print what actions it will undertake and since what modification date"
         )

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -190,6 +190,12 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         )
         deleted_arrangement.delete()
 
+    def setUp(self):
+        super().setUp()
+        self.elastic_client.indices.put_alias.reset_mock()
+        self.elastic_client.indices.create.reset_mock()
+        self.elastic_client.indices.delete.reset_mock()
+
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
     def test_edurep_surf_deletes(self, streaming_bulk, get_es_client):
@@ -295,8 +301,8 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
             "nl": 2
         }
         expected_index_configuration = {
-            "en": ElasticIndex.objects.get(language="en", dataset__name="test").configuration,
-            "nl": ElasticIndex.objects.get(language="nl", dataset__name="test").configuration
+            "en": ElasticIndex.get_index_config("en"),
+            "nl": ElasticIndex.get_index_config("nl")
         }
         get_es_client.reset_mock()
 
@@ -347,4 +353,64 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         for args, kwargs in self.elastic_client.indices.put_alias.call_args_list:
             index_name, language, id = kwargs["index"].split("-")
             self.assertEqual(index_name, "test")
+            self.assertIn(kwargs["name"], ["latest-nl", "latest-en"])
+
+    @patch("core.models.search.get_es_client", return_value=elastic_client)
+    @patch("core.models.search.streaming_bulk")
+    def test_edurep_surf_with_promote(self, streaming_bulk, get_es_client):
+
+        # Setting basic expectations used in the test
+        expected_doc_count = {
+            "en": 3,
+            "nl": 2
+        }
+        expected_index_configuration = {
+            "en": ElasticIndex.objects.get(language="en", dataset__name="test").configuration,
+            "nl": ElasticIndex.objects.get(language="nl", dataset__name="test").configuration
+        }
+
+        # Calling command and catching output for some checks
+        out = StringIO()
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger", stdout=out)
+
+        # Asserting output of command
+        stdout = out.getvalue().split("\n")
+        results = [rsl for rsl in stdout if rsl]
+        self.assertIn(
+            "since:2020-02-10, recreate:False and promote:True",
+            results,
+            "Expected command to print what actions it will undertake and since what modification date"
+        )
+        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
+                      "Expected command to print how many Dutch documents it encountered")
+        self.assertIn(f"en:{expected_doc_count['en']}", results,
+                      "Expected command to print how many English documents it encountered")
+        self.assertIn("unk:1", results,
+                      "Expected command to print how many documents it encountered with unknown language")
+
+        # Asserting calls to Elastic Search library
+        self.assertEqual(get_es_client.call_count, 4,
+                         "Expected an Elastic Search client to get created for each language")
+        for args, kwargs in streaming_bulk.call_args_list:
+            client, docs = args
+            index_name, language, id = kwargs["index"].split("-")
+            self.assertEqual(len(docs), expected_doc_count[language])
+            for doc in docs:
+                self.assert_document_structure(
+                    doc,
+                    doc["_id"] == "surf:oai:surfsharekit.nl:b500d389-2fda-4696-ae51-9cd0603a48af"
+                )
+
+            self.assertEqual(index_name, "test")
+        self.assertEqual(self.elastic_client.indices.delete.call_count, 0)
+        self.assertEqual(self.elastic_client.indices.create.call_count, 0)
+        for args, kwargs in self.elastic_client.indices.create.call_args_list:
+            index_name, language, id = kwargs["index"].split("-")
+            self.assertEqual(index_name, "test")
+            self.assertEqual(kwargs["body"], expected_index_configuration[language])
+        self.assertEqual(self.elastic_client.indices.put_alias.call_count, 2,
+                         "Expected an Elastic Search alias creation for each language")
+        for args, kwargs in self.elastic_client.indices.put_alias.call_args_list:
+            index_name, language, id = kwargs["index"].split("-")
+            self.assertIn(index_name, "test")
             self.assertIn(kwargs["name"], ["latest-nl", "latest-en"])

--- a/harvester/harvester/background.py
+++ b/harvester/harvester/background.py
@@ -52,8 +52,7 @@ def harvest(role="primary", reset=False):
         call_command("push_es_index", f"--dataset={dataset.name}", "--no-progress", *extra_push_index_args)
 
     # After processing all active datasets we dump the seeds and store on S3 so other nodes can use that
-    # TODO: only enable this when production can take on the role as primary (and legacy harvester will be ignored)
-    if role == "primary" and False:
+    if role == "primary":
         call_command("dump_resource", "edurep.EdurepOAIPMH")
         ctx = Context(environment)
         harvester_data_bucket = "s3://edushare-data/datasets/harvester/edurep"

--- a/harvester/package.py
+++ b/harvester/package.py
@@ -1,5 +1,5 @@
 PACKAGE = {
-    "version": "1.15.8",
+    "version": "1.15.9",
     "name": "harvester",
     "cpu": "2048",
     "memory": "8192"

--- a/service/e2e_tests/base.py
+++ b/service/e2e_tests/base.py
@@ -58,7 +58,13 @@ class ElasticSearchTestCase(BaseTestCase):
                         'type': 'keyword'
                     },
                     'authors': {
-                        'type': 'keyword'
+                        'type': 'text',
+                        'fields': {
+                            'keyword': {
+                                'type': 'keyword',
+                                'ignore_above': 256
+                            }
+                        }
                     },
                     'publishers': {
                         'type': 'keyword'

--- a/service/e2e_tests/test_search.py
+++ b/service/e2e_tests/test_search.py
@@ -27,6 +27,25 @@ class TestSearch(ElasticSearchTestCase):
         search.send_keys("Wiskunde")
         button.click()
 
+        WebDriverWait(self.selenium, 2).until_not(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "section.spinner")))
+
+        self.selenium.find_element_by_xpath("//*[text()[contains(., 'Didactiek van wiskundig denken')]]")
+
+    def test_search_by_author_from_searchbox(self):
+        self.selenium.get(self.live_server_url)
+
+        search = self.selenium.find_element_by_css_selector(".search.main__info_search input[type=search]")
+        button = self.selenium.find_element_by_css_selector(".search.main__info_search button")
+
+        search.send_keys("Theo")
+        button.click()
+
+        WebDriverWait(self.selenium, 2).until_not(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "section.spinner")))
+
+        search_results = self.selenium.find_elements_by_css_selector(".materials__item_wrapper.tile__wrapper")
+        self.assertEqual(len(search_results), 1)
         self.selenium.find_element_by_xpath("//*[text()[contains(., 'Didactiek van wiskundig denken')]]")
 
     def test_search_by_author(self):
@@ -35,6 +54,9 @@ class TestSearch(ElasticSearchTestCase):
 
         author_link = self.selenium.find_element_by_css_selector(".material__info_author a")
         author_link.click()
+
+        WebDriverWait(self.selenium, 2).until_not(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "section.spinner")))
 
         search_results = self.selenium.find_elements_by_css_selector(".materials__item_wrapper.tile__wrapper")
         self.assertEqual(len(search_results), 1)
@@ -45,6 +67,9 @@ class TestSearch(ElasticSearchTestCase):
 
         author_link = self.selenium.find_element_by_css_selector(".material__info_publishers a")
         author_link.click()
+
+        WebDriverWait(self.selenium, 2).until_not(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "section.spinner")))
 
         search_results = self.selenium.find_elements_by_css_selector(".materials__item_wrapper.tile__wrapper")
         self.assertEqual(len(search_results), 1)

--- a/service/package.py
+++ b/service/package.py
@@ -1,5 +1,5 @@
 PACKAGE = {
-    "version": "1.15.0",
+    "version": "1.15.1",
     "name": "search-portal",
     "cpu": "1024",
     "memory": "2048"

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -365,7 +365,7 @@ class ElasticSearchApiClient:
         elif external_id == 'lom.classification.obk.discipline.id':
             return 'disciplines'
         elif external_id == 'lom.lifecycle.contribute.author':
-            return 'authors'
+            return 'authors.keyword'
         elif external_id == 'lom.general.language':
             return 'language.keyword'
         elif external_id == 'lom.general.aggregationlevel':

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,7 @@ from commands.postgres.invoke import setup_postgres_localhost
 from commands.deploy import prepare_builds, build, push, deploy, migrate
 from commands.test import test_collection
 from commands.projects.service.invoke import import_snapshot
-from commands.projects.harvester.invoke import import_dataset, harvest, cleanup
+from commands.projects.harvester.invoke import import_dataset, harvest, cleanup, push_es_index
 from commands.legacy import download_media, upload_media
 
 
@@ -19,7 +19,8 @@ aws_collection.configure(service_environment)
 
 
 harvester_environment, _ = create_configuration_and_session(use_aws_default_profile=False, project="harvester")
-harvester_collection = Collection("hrv", setup_postgres_localhost, harvest, cleanup, import_dataset, deploy)
+harvester_collection = Collection("hrv", setup_postgres_localhost, harvest, cleanup, import_dataset, deploy,
+                                  push_es_index)
 harvester_collection.configure(harvester_environment)
 
 


### PR DESCRIPTION
This change in the index enables you to search for authors through the searchbox. It was not clear to me how I could update the index from the harvester. When I import the dataset all the documents have an unknown language. So I only tested it by creating a local test index and by writing an e2e-test. Next step is to create the index on all environments (I need some help with that 😉 ).