### PR TITLE
Escape community name

### DIFF
--- a/service/surf/apps/users/models.py
+++ b/service/surf/apps/users/models.py
@@ -22,7 +22,7 @@ class User(AbstractUser):
         communities = Community.objects.filter(team__user=self)
         if communities:
             communities = f"User is member of the following communities:<br>" \
-                f"{'<br>'.join([community.name for community in communities])}<br>"
+                f"{'<br>'.join([escape(community.name) for community in communities])}<br>"
         else:
             communities = "User is not a member of any communities<br>"
 


### PR DESCRIPTION
Problem was that community names aren't escaped. Other user provided input was already escaped and only hard-coded HTML is now used. Therefore it doesn't impose any security risks anymore. This is a much faster fix than stripping away the HTML.