### PR TITLE
Update packages with security issues

### DIFF
--- a/harvester/dependencies.txt
+++ b/harvester/dependencies.txt
@@ -21,7 +21,7 @@ pytz==2020.1
 urlobject==2.4.3
 pandas==0.23.4
 git+https://github.com/fako/django-json-field.git
-lxml==4.5.2
+lxml==4.6.1
 beautifulsoup4==4.9.1
 datagrowth==0.16.3
 

--- a/harvester/requirements.txt
+++ b/harvester/requirements.txt
@@ -1,6 +1,6 @@
 # Common
 django==2.2.13
-djangorestframework==3.11.0
+djangorestframework==3.11.2
 django-cors-headers==3.4.0
 whitenoise==5.1.0
 psycopg2-binary==2.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flake8==3.8.3
 
 # Common
 django==2.2.13
-djangorestframework==3.11.0
+djangorestframework==3.11.2
 django-cors-headers==3.4.0
 whitenoise==5.1.0
 psycopg2-binary==2.8.5

--- a/service/dependencies.txt
+++ b/service/dependencies.txt
@@ -1,5 +1,5 @@
 # Service Django
-django-filter==2.3.0
+django-filter==2.4.0
 django-3-jet==1.0.8
 django-ckeditor==5.9.0
 django-mptt==0.11.0

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,6 +1,6 @@
 # Common
 django==3.0.8
-djangorestframework==3.11.0
+djangorestframework==3.11.2
 psycopg2-binary==2.8.5
 whitenoise==5.1.0
 requests==2.24.0


### PR DESCRIPTION
Fixes issues with django-filter, but also lxml and djangorestframework apparently have security risks. So I have also updated those packages. The ticket also mentioned django-celery-results. But there isn't a new version and it isn't really a security risk. The problem is that it stores arguments for tasks in plain text. See: https://github.com/celery/django-celery-results/issues/154