### PR TITLE
Keep active community tab in state

### DIFF
--- a/portal/src/components/Tab.vue
+++ b/portal/src/components/Tab.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="isActive" class="tabcontent">
+  <div v-show="isActive" class="tab-content">
     <slot></slot>
   </div>
 </template>
@@ -26,7 +26,7 @@ export default {
 <style lang="less" scoped>
 @import url('../variables');
 
-.tabcontent {
+.tab-content {
   margin-top: 50px;
 
   @media @mobile {

--- a/portal/src/components/Tabs.vue
+++ b/portal/src/components/Tabs.vue
@@ -16,10 +16,19 @@
   </div>
 </template>
 <script>
-import { mapGetters } from 'vuex'
-
 export default {
   name: 'Tabs',
+  props: {
+    activeIndex: {
+      type: Number,
+      default: 0
+    },
+    setTab: {
+      type: Function,
+      params: 1,
+      default: () => {}
+    }
+  },
   data() {
     return {
       selectedIndex: 0,
@@ -27,7 +36,6 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['communityActiveTab']),
     activeTab() {
       const tab = this.tabs.find(tab => tab.isActive)
       return tab && tab.identifier
@@ -37,12 +45,12 @@ export default {
     this.tabs = this.$children.filter(c => {
       return c.$slots.default
     })
-    this.selectTab(this.communityActiveTab)
+    this.selectTab(this.activeIndex)
   },
   methods: {
     selectTab(index) {
       this.selectedIndex = index
-      this.$store.commit('SET_COMMUNITY_ACTIVE_TAB', index)
+      this.setTab(index)
       this.tabs.forEach((tab, i) => (tab.isActive = index === i))
     }
   }

--- a/portal/src/components/Tabs.vue
+++ b/portal/src/components/Tabs.vue
@@ -16,6 +16,8 @@
   </div>
 </template>
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'Tabs',
   data() {
@@ -25,6 +27,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['communityActiveTab']),
     activeTab() {
       const tab = this.tabs.find(tab => tab.isActive)
       return tab && tab.identifier
@@ -34,12 +37,12 @@ export default {
     this.tabs = this.$children.filter(c => {
       return c.$slots.default
     })
-    this.selectTab(0)
+    this.selectTab(this.communityActiveTab)
   },
   methods: {
     selectTab(index) {
       this.selectedIndex = index
-
+      this.$store.commit('SET_COMMUNITY_ACTIVE_TAB', index)
       this.tabs.forEach((tab, i) => (tab.isActive = index === i))
     }
   }

--- a/portal/src/pages/communities.vue
+++ b/portal/src/pages/communities.vue
@@ -3,7 +3,11 @@
     <section class="communities">
       <HeaderBlock :title="$t('Communities')" />
       <div class="center_block">
-        <Tabs v-if="user.id && userCommunities(user).length">
+        <Tabs
+          v-if="user.id && userCommunities(user).length"
+          :active-index="communitiesActiveTab"
+          :set-tab="setTab"
+        >
           <template v-slot:after-tabs>
             <SwitchInput
               v-model="showDrafts"
@@ -90,7 +94,12 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['user', 'allCommunities', 'userCommunities']),
+    ...mapGetters([
+      'user',
+      'allCommunities',
+      'userCommunities',
+      'communitiesActiveTab'
+    ]),
     communities() {
       if (this.showDrafts) {
         return this.allCommunities(this.user)
@@ -120,6 +129,9 @@ export default {
       }
 
       return this.user.communities.some(id => id === community.id)
+    },
+    setTab(index) {
+      this.$store.commit('SET_COMMUNITIES_ACTIVE_TAB', index)
     }
   }
 }

--- a/portal/src/pages/my/community.vue
+++ b/portal/src/pages/my/community.vue
@@ -51,7 +51,7 @@
           />
         </div>
         <div v-show="!previewMode">
-          <Tabs>
+          <Tabs :active-index="myCommunityActiveTab" :set-tab="setTab">
             <template v-slot:after-tabs="slotProps">
               <div
                 v-if="slotProps.activeTab === 'collections-tab'"
@@ -147,7 +147,6 @@ export default {
       errors: {},
       formData: null,
       notFound: false,
-      currentTab: 'general',
       previewMode: false
     }
   },
@@ -158,7 +157,8 @@ export default {
       'communities',
       'isAuthenticated',
       'user',
-      'userCommunities'
+      'userCommunities',
+      'myCommunityActiveTab'
     ]),
     isPublished: {
       get() {
@@ -368,6 +368,9 @@ export default {
     },
     setCollectionSelection(selection) {
       this.selection = selection
+    },
+    setTab(index) {
+      this.$store.commit('SET_MY_COMMUNITY_ACTIVE_TAB', index)
     }
   }
 }

--- a/portal/src/store/modules/communities.js
+++ b/portal/src/store/modules/communities.js
@@ -14,7 +14,8 @@ export default {
     community_disciplines: null,
     community_collections: null,
     community_collections_loading: null,
-    community_active_tab: 0
+    my_community_active_tab: 0,
+    communities_active_tab: 0
   },
   getters: {
     communities(state) {
@@ -97,8 +98,11 @@ export default {
         })
       }
     },
-    communityActiveTab(state) {
-      return state.community_active_tab
+    myCommunityActiveTab(state) {
+      return state.my_community_active_tab
+    },
+    communitiesActiveTab(state) {
+      return state.communities_active_tab
     }
   },
   actions: {
@@ -257,8 +261,11 @@ export default {
     SET_COMMUNITY_COLLECTIONS_LOADING(state, payload) {
       state.community_collections_loading = payload
     },
-    SET_COMMUNITY_ACTIVE_TAB(state, payload) {
-      state.community_active_tab = payload
+    SET_MY_COMMUNITY_ACTIVE_TAB(state, payload) {
+      state.my_community_active_tab = payload
+    },
+    SET_COMMUNITIES_ACTIVE_TAB(state, payload) {
+      state.communities_active_tab = payload
     }
   }
 }

--- a/portal/src/store/modules/communities.js
+++ b/portal/src/store/modules/communities.js
@@ -13,7 +13,8 @@ export default {
     community_themes: null,
     community_disciplines: null,
     community_collections: null,
-    community_collections_loading: null
+    community_collections_loading: null,
+    community_active_tab: 0
   },
   getters: {
     communities(state) {
@@ -95,6 +96,9 @@ export default {
           )
         })
       }
+    },
+    communityActiveTab(state) {
+      return state.community_active_tab
     }
   },
   actions: {
@@ -252,6 +256,9 @@ export default {
     },
     SET_COMMUNITY_COLLECTIONS_LOADING(state, payload) {
       state.community_collections_loading = payload
+    },
+    SET_COMMUNITY_ACTIVE_TAB(state, payload) {
+      state.community_active_tab = payload
     }
   }
 }


### PR DESCRIPTION
In my community the active tab was always the general tab with the form details. It now keeps the active tab in the state to improve navigation in the collections tab.

![Screenshot 2020-11-19 at 17 39 51](https://user-images.githubusercontent.com/7254238/99695804-4964d680-2a8e-11eb-8125-df06b76c12ae.png)
