### PR TITLE
Privacy page flow

### DIFF
--- a/portal/src/components/Popup/DeleteAccountPopup.vue
+++ b/portal/src/components/Popup/DeleteAccountPopup.vue
@@ -1,0 +1,55 @@
+<template>
+  <transition name="fade">
+    <Popup
+      v-if="showPopup"
+      :close="close"
+      :is-show="showPopup"
+      class="popup-content"
+    >
+      <slot>
+        <h2 class="popup__title">{{ $t('Delete-account') }}</h2>
+        <div class="popup__subtext">
+          {{ $t('Are-you-sure-you-want-to-delete-this-account') }}
+        </div>
+        <div>
+          <div class="popup-content__actions">
+            <button class="button" @click="deleteAccount">
+              {{ $t('Yes-delete-it') }}
+            </button>
+          </div>
+        </div>
+      </slot>
+    </Popup>
+  </transition>
+</template>
+
+<script>
+import Popup from '~/components/Popup'
+
+export default {
+  name: 'DeleteAccountPopup',
+  components: {
+    Popup
+  },
+  props: {
+    showPopup: {
+      type: Boolean,
+      default: false
+    },
+    deleteAccount: {
+      type: Function,
+      default: () => {}
+    },
+    close: {
+      type: Function,
+      default: () => {}
+    }
+  }
+}
+</script>
+
+<style
+  src="./DeleteCollection/DeleteCollection.component.less"
+  scoped
+  lang="less"
+/>

--- a/portal/src/components/Popup/DeleteCollection/DeleteCollection.component.html
+++ b/portal/src/components/Popup/DeleteCollection/DeleteCollection.component.html
@@ -1,19 +1,13 @@
 <transition name="fade">
-  <Popup
-    v-if="isShow"
-    :close="close"
-    :is-show="isShow"
-    class="delete-collection"
-  >
+  <Popup v-if="isShow" :close="close" :is-show="isShow" class="popup-content">
     <slot>
       <h2 class="popup__title">{{ $t('Remove-collection') }}</h2>
-      <div class="popup__subtext">{{ $t('Are-you-sure-you-want-to-delete-this-collection') }}</div>
+      <div class="popup__subtext">
+        {{ $t('Are-you-sure-you-want-to-delete-this-collection') }}
+      </div>
       <div>
-        <div class="share-collection__actions">
-          <button
-            class="button"
-            @click="deleteCollection"
-          >
+        <div class="popup-content__actions">
+          <button class="button" @click="deleteCollection">
             {{ $t('Yes-delete-it') }}
           </button>
         </div>

--- a/portal/src/components/Popup/DeleteCollection/DeleteCollection.component.less
+++ b/portal/src/components/Popup/DeleteCollection/DeleteCollection.component.less
@@ -1,5 +1,5 @@
 @import './../../../variables';
-.delete-collection {
+.popup-content {
   .popup__subtext{
     margin-bottom: 37px;
   }

--- a/portal/src/pages/my/privacy.vue
+++ b/portal/src/pages/my/privacy.vue
@@ -174,9 +174,19 @@ export default {
   methods: {
     deleteAccount() {
       this.isSubmitting = true
-      this.$store.dispatch('deleteUser').then(() => {
-        this.$store.dispatch('logout', { fully: true })
-      })
+      this.$store
+        .dispatch('deleteUser')
+        .then(() => {
+          this.$store.dispatch('logout', { fully: true })
+        })
+        .catch(error => {
+          if (error) {
+            this.$store.commit('ADD_MESSAGE', {
+              level: 'error',
+              message: 'Session-expired'
+            })
+          }
+        })
       this.closeDeleteAccountPopup()
     },
     onSubmit() {

--- a/portal/src/pages/my/privacy.vue
+++ b/portal/src/pages/my/privacy.vue
@@ -177,7 +177,14 @@ export default {
   },
   methods: {
     deleteAccount() {
-      this.submit()
+      this.isSubmitting = true
+      this.$store.dispatch('deleteUser').then(() => {
+        this.isSaved = true
+        setTimeout(() => {
+          this.isSaved = false
+          this.$store.dispatch('logout', { fully: true })
+        })
+      })
       this.closeDeleteAccountPopup()
     },
     onSubmit() {

--- a/portal/src/store/modules/user.js
+++ b/portal/src/store/modules/user.js
@@ -78,9 +78,9 @@ export default {
       commit('SET_USER', state.user)
       commit('USER_LOADING', false)
     },
-    async deleteUser({ commit, state }) {
+    async deleteUser({ commit }) {
       commit('USER_LOADING', true)
-      await axios.post(`users/delete-account/`, state.user)
+      await axios.post(`users/delete-account/`)
       commit('USER_LOADING', false)
     },
     async authenticate({ commit }, { token }) {

--- a/portal/src/store/modules/user.js
+++ b/portal/src/store/modules/user.js
@@ -78,10 +78,8 @@ export default {
       commit('SET_USER', state.user)
       commit('USER_LOADING', false)
     },
-    async deleteUser({ commit }) {
-      commit('USER_LOADING', true)
-      await axios.post(`users/delete-account/`)
-      commit('USER_LOADING', false)
+    async deleteUser() {
+      return await axios.post(`users/delete-account/`)
     },
     async authenticate({ commit }, { token }) {
       if (!token) {

--- a/portal/src/store/modules/user.js
+++ b/portal/src/store/modules/user.js
@@ -78,6 +78,11 @@ export default {
       commit('SET_USER', state.user)
       commit('USER_LOADING', false)
     },
+    async deleteUser({ commit, state }) {
+      commit('USER_LOADING', true)
+      await axios.post(`users/delete-account/`, state.user)
+      commit('USER_LOADING', false)
+    },
     async authenticate({ commit }, { token }) {
       if (!token) {
         return

--- a/service/e2e_tests/factories.py
+++ b/service/e2e_tests/factories.py
@@ -3,6 +3,9 @@ from surf.apps.users.models import User
 from surf.apps.communities.models import Community, CommunityDetail, Team
 from surf.statusenums import PublishStatus
 from surf.apps.materials.models import Collection, Material
+from surf.vendor.surfconext.models import DataGoalPermission, DataGoal, PrivacyStatement
+
+from django.utils.timezone import now
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -16,6 +19,50 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_superuser = True
     is_staff = True
     is_active = True
+
+
+class PrivacyStatementFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = PrivacyStatement
+
+    name = "Communities"
+    is_active = True
+    en = "English text"
+    nl = "Nederlandse text"
+    created_at = "2019-12-06T13:23:59.167Z",
+    modified_at = "2020-04-02T11:42:57.279Z"
+
+
+class DataGoalFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = DataGoal
+
+    type = 'Communities'
+    statement = factory.SubFactory(PrivacyStatementFactory)
+    is_active = True
+    priority = 1
+    is_notification_only = False
+    is_after_login = True
+    more_info_route = 'privacy'
+    en_title = 'Communities'
+    nl_title = 'Communities'
+    en_description = 'If you create an account by logging in with SURFconext a unique identifier, your email address ' \
+                     'and your SURFconext group memberships will also be used. The search portal uses this ' \
+                     'information to determine which communities you can manage.'
+    nl_description = 'Als je een account aanmaakt door in te loggen met SURFconext  dan verwerken we een unieke ' \
+                     'identifier, je e-mailadres en je groepslidmaatschappen van SURFconext. Het zoekportaal bepaalt ' \
+                     'met die informatie welke communities je beheert.'
+
+
+class DataGoalPermissionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = DataGoalPermission
+
+    user = factory.SubFactory(UserFactory)
+    goal = factory.SubFactory(DataGoalFactory)
+    recorded_at = now()
+    is_allowed = True
+    is_retained = True
 
 
 class CommunityDetailFactory(factory.django.DjangoModelFactory):

--- a/service/e2e_tests/test_collections.py
+++ b/service/e2e_tests/test_collections.py
@@ -30,7 +30,7 @@ class TestCollections(BaseTestCase):
         self.selenium.get(f"{self.live_server_url}/mijn/community/{self.community.id}")
         self.selenium.find_element_by_css_selector(".collections-tab").click()
         self.selenium.find_element_by_css_selector(".collections__item .select-icon").click()
-        self.selenium.find_element_by_css_selector(".popup.delete-collection .share-collection__actions button").click()
+        self.selenium.find_element_by_css_selector(".popup.popup-content .share-collection__actions button").click()
         WebDriverWait(self.selenium, 2).until(
             EC.text_to_be_present_in_element((By.CSS_SELECTOR, ".collections"), "Geen collecties")
         )

--- a/service/e2e_tests/test_collections.py
+++ b/service/e2e_tests/test_collections.py
@@ -30,7 +30,7 @@ class TestCollections(BaseTestCase):
         self.selenium.get(f"{self.live_server_url}/mijn/community/{self.community.id}")
         self.selenium.find_element_by_css_selector(".collections-tab").click()
         self.selenium.find_element_by_css_selector(".collections__item .select-icon").click()
-        self.selenium.find_element_by_css_selector(".popup.popup-content .share-collection__actions button").click()
+        self.selenium.find_element_by_css_selector(".popup.popup-content .popup-content__actions button").click()
         WebDriverWait(self.selenium, 2).until(
             EC.text_to_be_present_in_element((By.CSS_SELECTOR, ".collections"), "Geen collecties")
         )

--- a/service/e2e_tests/test_users.py
+++ b/service/e2e_tests/test_users.py
@@ -1,0 +1,49 @@
+from django.test import override_settings
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+
+from e2e_tests.base import BaseTestCase
+from e2e_tests.factories import UserFactory, DataGoalPermissionFactory
+from e2e_tests.helpers import login
+
+
+class TestUsers(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create()
+        self.data_goal_permission = DataGoalPermissionFactory.create(user=self.user)
+        login(self, self.user)
+
+    @override_settings(DEBUG=True)
+    def test_delete_user(self):
+        self.selenium.get(f"{self.live_server_url}/mijn/privacy")
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, ".info .title"), "Mijn privacy"
+            ),
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, ".privacy__form__label"), "Communities"
+            ),
+        )
+        self.selenium.find_element_by_css_selector(".privacy input").is_selected()
+        self.selenium.find_element_by_css_selector(".permission-container .switch-input").click()
+
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, ".privacy__form__button"), "Delete-account-and-login"
+            )
+        )
+
+        self.selenium.find_element_by_css_selector(".privacy__form__button").click()
+
+        WebDriverWait(self.selenium, 2).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, ".popup__title"), "Delete-account"
+            )
+        )
+        self.selenium.find_element_by_css_selector(".popup-content__actions button").click()
+
+        WebDriverWait(self.selenium, 2).until(
+            EC.url_to_be("https://engine.surfconext.nl/logout")
+        )

--- a/service/surf/apps/users/authentication.py
+++ b/service/surf/apps/users/authentication.py
@@ -10,7 +10,8 @@ class SessionTokenAuthentication(TokenAuthentication):
 
 def delete_api_auth_token(sender, user, request, **kwargs):
     try:
-        user.auth_token.delete()
+        if user is not None:
+            user.auth_token.delete()
     except SessionToken.DoesNotExist:
         pass
 

--- a/service/surf/apps/users/views.py
+++ b/service/surf/apps/users/views.py
@@ -89,10 +89,10 @@ class ObtainTokenAPIView(APIView):
 
 
 class DeleteAccountAPIView(APIView):
+
+    permission_classes = (IsAuthenticated,)
+
     def post(self, request, *args, **kwargs):
-        if request.user.is_authenticated:
-            user = User.objects.get(id=request.user.id)
-            user.delete()
-            return Response(status=status.HTTP_200_OK)
-        else:
-            raise AuthenticationFailed()
+        user = User.objects.get(id=request.user.id)
+        user.delete()
+        return Response(status=status.HTTP_200_OK)

--- a/service/surf/apps/users/views.py
+++ b/service/surf/apps/users/views.py
@@ -5,12 +5,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
 
 from django.views.decorators.cache import never_cache
 from django.contrib.sessions.models import Session
 
 from surf.vendor.surfconext.models import PrivacyStatement, DataGoalPermissionSerializer
-from surf.apps.users.models import SessionToken
+from surf.apps.users.models import SessionToken, User
 from surf.apps.users.serializers import UserDetailsSerializer
 
 
@@ -83,3 +84,10 @@ class ObtainTokenAPIView(APIView):
         if "permissions" in request.session:
             del request.session["permissions"]
         return Response({'token': token.key})
+
+
+class DeleteAccountAPIView(APIView):
+    def post(self, request, *args, **kwargs):
+        user = User.objects.get(id=request.data["id"])
+        user.delete()
+        return Response(status=status.HTTP_200_OK)

--- a/service/surf/apps/users/views.py
+++ b/service/surf/apps/users/views.py
@@ -88,6 +88,6 @@ class ObtainTokenAPIView(APIView):
 
 class DeleteAccountAPIView(APIView):
     def post(self, request, *args, **kwargs):
-        user = User.objects.get(id=request.data["id"])
+        user = User.objects.get(id=request.user.id)
         user.delete()
         return Response(status=status.HTTP_200_OK)

--- a/service/surf/apps/users/views.py
+++ b/service/surf/apps/users/views.py
@@ -1,4 +1,6 @@
 import logging
+
+from rest_framework.exceptions import AuthenticationFailed
 from sentry_sdk import capture_message
 
 from rest_framework.response import Response
@@ -88,6 +90,9 @@ class ObtainTokenAPIView(APIView):
 
 class DeleteAccountAPIView(APIView):
     def post(self, request, *args, **kwargs):
-        user = User.objects.get(id=request.user.id)
-        user.delete()
-        return Response(status=status.HTTP_200_OK)
+        if request.user.is_authenticated:
+            user = User.objects.get(id=request.user.id)
+            user.delete()
+            return Response(status=status.HTTP_200_OK)
+        else:
+            raise AuthenticationFailed()

--- a/service/surf/apps/users/views.py
+++ b/service/surf/apps/users/views.py
@@ -1,6 +1,5 @@
 import logging
 
-from rest_framework.exceptions import AuthenticationFailed
 from sentry_sdk import capture_message
 
 from rest_framework.response import Response

--- a/service/surf/urls.py
+++ b/service/surf/urls.py
@@ -40,6 +40,7 @@ from surf.apps.filters.views import (
     MpttFilterItems
 )
 from surf.apps.users.views import (
+    DeleteAccountAPIView,
     UserDetailsAPIView,
     ObtainTokenAPIView
 )
@@ -62,6 +63,7 @@ router.register(r'stats', StatsView, basename="stats")
 
 apipatterns = [
     url(r'^users/me/', UserDetailsAPIView.as_view()),
+    url(r'^users/delete-account/', DeleteAccountAPIView.as_view()),
     url(r'^users/obtain-token/', ObtainTokenAPIView.as_view()),
     url(r'^keywords/', KeywordsAPIView.as_view()),
     url(r'^rate_material/', MaterialRatingAPIView.as_view()),


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175934292:

Op de mijn privacy pagina moet de flow iets aangepast worden.
Als een gebruiker alle knopjes (nu hebben we alleen communities), op uit zet bieden we hem/haar de keuze om de account te verwijderen.
De gele knop wordt dan rood en als die aangeklikt wordt verschijnt een korte modal (vergelijkbaar met als je een collectie verwijderd) met de vraag of de gebruiker zeker is. Zo ja, dan de informatie van de gebruiker verwijderen uit de database en uitloggen.