### PR TITLE
Allows year-month dates as publisher date in ES

### DIFF
--- a/harvester/core/models/search.py
+++ b/harvester/core/models/search.py
@@ -140,7 +140,8 @@ class ElasticIndex(models.Model):
                         'type': 'keyword'
                     },
                     'publisher_date': {
-                        'type': 'date'
+                        'type': 'date',
+                        'format': 'strict_date_optional_time||yyyy-MM||epoch_millis'
                     },
                     'aggregation_level': {
                         'type': 'keyword'


### PR DESCRIPTION
Keeps default as is, but adds yyyy-MM as extra date format.