### PR TITLE
Fix sending to Sentry when there is no user agent

### DIFF
--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -209,7 +209,11 @@ LOGGING = {
 if not DEBUG:
 
     def strip_sensitive_data(event, hint):
-        del event['request']['headers']['User-Agent']
+        user_agent = event.get('request', {}).get('headers', {}).get('User-Agent', None)
+
+        if user_agent:
+            del event['request']['headers']['User-Agent']
+
         return event
 
     sentry_sdk.init(

--- a/harvester/requirements.txt
+++ b/harvester/requirements.txt
@@ -20,6 +20,6 @@ ipython==7.16.1
 tqdm==4.50.2
 invoke==1.4.1
 ipdb==0.13.3
-sentry-sdk==0.16.2
+sentry-sdk==0.19.5
 
 -r dependencies.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ tqdm==4.50.2
 invoke==1.4.1
 fabric==2.5.0
 ipdb==0.13.3
-sentry-sdk==0.16.2
+sentry-sdk==0.19.5
 selenium==3.141.0
 factory_boy==2.12.0
 

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -19,6 +19,6 @@ ipython==7.16.1
 tqdm==4.50.2
 invoke==1.4.1
 ipdb==0.13.3
-sentry-sdk==0.16.2
+sentry-sdk==0.19.5
 
 -r dependencies.txt

--- a/service/surf/settings/base.py
+++ b/service/surf/settings/base.py
@@ -258,8 +258,11 @@ WEBPACK_LOADER = {
 if not DEBUG:
 
     def strip_sensitive_data(event, hint):
-        # modify event here
-        del event['request']['headers']['User-Agent']
+        user_agent = event.get('request', {}).get('headers', {}).get('User-Agent', None)
+
+        if user_agent:
+            del event['request']['headers']['User-Agent']
+
         return event
 
     # Initiates sentry without sending personal data


### PR DESCRIPTION
After long debugging I found out that actually the before_send of sentry fails because there is no User-Agent when it isn't a web request. However this isn't reported in Sentry of course and also not reflected in the stacktrace 🙈 .

This fixes it.