### PR TITLE
Improve harvester logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 /data
 /venv
 /elastic
+harvester/logs/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@
 /data
 /venv
 /elastic
-harvester/logs/*

--- a/commands/aws/ecs.py
+++ b/commands/aws/ecs.py
@@ -49,6 +49,10 @@ def run_task(ctx, target, mode, command, environment=None, version=None, extra_w
     session = create_aws_session(profile_name=ctx.config.aws.profile_name)
     ecs_client = session.client('ecs')
     container_variables = build_default_container_variables(mode, version)
+    container_variables.update({
+        "harvester_bucket": ctx.config.aws.harvest_content_bucket
+    })
+
     if extra_workers:
         container_variables.update({
             "concurrency": f"{concurrency}"

--- a/commands/deploy/deploy.py
+++ b/commands/deploy/deploy.py
@@ -56,7 +56,8 @@ def deploy_harvester(ctx, mode, ecs_client, task_role_arn, version):
     target_info = TARGETS["harvester"]
     harvester_container_variables = build_default_container_variables(mode, version)
     harvester_container_variables.update({
-        "flower_secret_arn": ctx.config.aws.flower_secret_arn
+        "flower_secret_arn": ctx.config.aws.flower_secret_arn,
+        "harvester_bucket": ctx.config.aws.harvest_content_bucket
     })
 
     harvester_task_definition_arn = register_task_definition(

--- a/environments/acceptance/harvester/invoke.yml
+++ b/environments/acceptance/harvester/invoke.yml
@@ -6,6 +6,8 @@ django:
     - "core/fixtures/datasets-history.json"
     - "edurep/fixtures/surf-oaipmh-1970-01-01.json"
   redis_host: "harvester.2rmfel.0001.euc1.cache.amazonaws.com:6379"
+  logging:
+    level: "INFO"
 
 postgres:
   database: "harvester"

--- a/environments/acceptance/harvester/invoke.yml
+++ b/environments/acceptance/harvester/invoke.yml
@@ -8,6 +8,7 @@ django:
   redis_host: "harvester.2rmfel.0001.euc1.cache.amazonaws.com:6379"
   logging:
     level: "INFO"
+    handler: "json"
 
 postgres:
   database: "harvester"

--- a/environments/development/harvester/invoke.yml
+++ b/environments/development/harvester/invoke.yml
@@ -6,6 +6,8 @@ django:
     - "core/fixtures/datasets-history.json"
     - "edurep/fixtures/surf-oaipmh-1970-01-01.json"
   redis_host: "harvester.2w7uxm.0001.euc1.cache.amazonaws.com:6379"
+  logging:
+    level: "DEBUG"
 
 postgres:
   database: "harvester"

--- a/environments/development/harvester/invoke.yml
+++ b/environments/development/harvester/invoke.yml
@@ -8,6 +8,7 @@ django:
   redis_host: "harvester.2w7uxm.0001.euc1.cache.amazonaws.com:6379"
   logging:
     level: "DEBUG"
+    handler: "json"
 
 postgres:
   database: "harvester"

--- a/environments/localhost/harvester/invoke.yml
+++ b/environments/localhost/harvester/invoke.yml
@@ -4,6 +4,8 @@ django:
     - "core/fixtures/datasets-history.json"
     - "edurep/fixtures/surf-oaipmh-1970-01-01.json"
   redis_host: "redis:6379"
+  logging:
+    level: "DEBUG"
 
 postgres:
   database: "harvester"

--- a/environments/localhost/harvester/invoke.yml
+++ b/environments/localhost/harvester/invoke.yml
@@ -6,6 +6,7 @@ django:
   redis_host: "redis:6379"
   logging:
     level: "DEBUG"
+    handler: "console"
 
 postgres:
   database: "harvester"

--- a/environments/production/harvester/invoke.yml
+++ b/environments/production/harvester/invoke.yml
@@ -7,7 +7,7 @@ django:
     - "edurep/fixtures/surf-oaipmh-1970-01-01.json"
   redis_host: "harvester.o1edd0.0001.euc1.cache.amazonaws.com:6379"
   logging:
-    level: "WARNING"
+    level: "INFO"
     handler: "json"
 
 postgres:

--- a/environments/production/harvester/invoke.yml
+++ b/environments/production/harvester/invoke.yml
@@ -6,6 +6,8 @@ django:
     - "core/fixtures/datasets-history.json"
     - "edurep/fixtures/surf-oaipmh-1970-01-01.json"
   redis_host: "harvester.o1edd0.0001.euc1.cache.amazonaws.com:6379"
+  logging:
+    level: "WARNING"
 
 postgres:
   database: "harvester"

--- a/environments/production/harvester/invoke.yml
+++ b/environments/production/harvester/invoke.yml
@@ -8,6 +8,7 @@ django:
   redis_host: "harvester.o1edd0.0001.euc1.cache.amazonaws.com:6379"
   logging:
     level: "WARNING"
+    handler: "json"
 
 postgres:
   database: "harvester"

--- a/harvester/aws-container-definitions.json
+++ b/harvester/aws-container-definitions.json
@@ -1,81 +1,87 @@
 [
-    {
-        "name": "harvester-container",
-        "image": "${REPOSITORY}/harvester:${version}",
-        "cpu": 0,
-        "essential": true,
-        "portMappings": [
-            {
-                "hostPort": 8080,
-                "protocol": "tcp",
-                "containerPort": 8080
-            }
-        ],
-        "environment": [
-            { "name" : "PYTHONUNBUFFERED", "value" : "1" },
-            { "name" : "APPLICATION_MODE", "value" : "${mode}" }
-        ],
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-                "awslogs-group": "/ecs/harvester",
-                "awslogs-region": "eu-central-1",
-                "awslogs-stream-prefix": "harvester-${version}",
-                "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-            }
-        }
-    },
-    {
-      "name": "celery-beat-container",
-      "image": "${REPOSITORY}/harvester:${version}",
-      "cpu": 512,
-      "essential": true,
-      "command": ["celery", "-A", "harvester", "beat", "-s", "/tmp/celerybeat-schedule"],
-      "environment": [
-        { "name" : "PYTHONUNBUFFERED", "value" : "1" },
-        { "name" : "APPLICATION_MODE", "value" : "${mode}" }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "/ecs/harvester",
-          "awslogs-region": "eu-central-1",
-          "awslogs-stream-prefix": "celery-beat-${version}",
-          "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-        }
+  {
+    "essential": true,
+    "image": "906394416424.dkr.ecr.eu-central-1.amazonaws.com/aws-for-fluent-bit:latest",
+    "name": "log_router",
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::${harvester_bucket}/fluent.conf"
       }
     },
-    {
-      "name": "flower-container",
-      "image": "${REPOSITORY}/harvester:${version}",
-      "cpu": 0,
-      "essential": true,
-      "portMappings": [
-        {
-          "hostPort": 5555,
-          "protocol": "tcp",
-          "containerPort": 5555
-        }
-      ],
-      "command": ["celery", "-A", "harvester", "flower"],
-      "environment": [
-        { "name" : "PYTHONUNBUFFERED", "value" : "1" },
-        { "name" : "APPLICATION_MODE", "value" : "${mode}" }
-      ],
-      "secrets": [
-        {
-          "name" : "FLOWER_BASIC_AUTH",
-          "valueFrom":  "${flower_secret_arn}"
-        }
-      ],
-      "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-          "awslogs-group": "/ecs/harvester",
-          "awslogs-region": "eu-central-1",
-          "awslogs-stream-prefix": "flower-${version}",
-          "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-        }
+    "environment": [
+      { "name" : "VERSION", "value" : "${version}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "firelens-container",
+        "awslogs-region": "eu-central-1",
+        "awslogs-stream-prefix": "firelens"
       }
+    },
+    "memoryReservation": 50
+  },
+  {
+    "name": "harvester-container",
+    "image": "${REPOSITORY}/harvester:${version}",
+    "cpu": 0,
+    "essential": true,
+    "portMappings": [
+      {
+        "hostPort": 8080,
+        "protocol": "tcp",
+        "containerPort": 8080
+      }
+    ],
+    "environment": [
+      { "name" : "PYTHONUNBUFFERED", "value" : "1" },
+      { "name" : "APPLICATION_MODE", "value" : "${mode}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awsfirelens"
     }
+  },
+  {
+    "name": "celery-beat-container",
+    "image": "${REPOSITORY}/harvester:${version}",
+    "cpu": 512,
+    "essential": true,
+    "command": ["celery", "-A", "harvester", "beat", "-s", "/tmp/celerybeat-schedule"],
+    "environment": [
+      { "name" : "PYTHONUNBUFFERED", "value" : "1" },
+      { "name" : "APPLICATION_MODE", "value" : "${mode}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awsfirelens"
+    }
+  },
+  {
+    "name": "flower-container",
+    "image": "${REPOSITORY}/harvester:${version}",
+    "cpu": 0,
+    "essential": true,
+    "portMappings": [
+      {
+        "hostPort": 5555,
+        "protocol": "tcp",
+        "containerPort": 5555
+      }
+    ],
+    "command": ["celery", "-A", "harvester", "flower"],
+    "environment": [
+      { "name" : "PYTHONUNBUFFERED", "value" : "1" },
+      { "name" : "APPLICATION_MODE", "value" : "${mode}" }
+    ],
+    "secrets": [
+      {
+        "name" : "FLOWER_BASIC_AUTH",
+        "valueFrom":  "${flower_secret_arn}"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awsfirelens"
+    }
+  }
 ]

--- a/harvester/celery-container-definitions.json
+++ b/harvester/celery-container-definitions.json
@@ -1,5 +1,29 @@
 [
   {
+    "essential": true,
+    "image": "906394416424.dkr.ecr.eu-central-1.amazonaws.com/aws-for-fluent-bit:latest",
+    "name": "log_router",
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::${harvester_bucket}/fluent.conf"
+      }
+    },
+    "environment": [
+      { "name" : "VERSION", "value" : "${version}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "firelens-container",
+        "awslogs-region": "eu-central-1",
+        "awslogs-stream-prefix": "firelens"
+      }
+    },
+    "memoryReservation": 50
+  },
+  {
     "name": "celery-worker-container",
     "image": "${REPOSITORY}/harvester:${version}",
     "cpu": 0,
@@ -10,13 +34,7 @@
       { "name" : "APPLICATION_MODE", "value" : "${mode}" }
     ],
     "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "/ecs/harvester",
-        "awslogs-region": "eu-central-1",
-        "awslogs-stream-prefix": "celery-worker-${version}",
-        "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-      }
+      "logDriver": "awsfirelens"
     }
   }
 ]

--- a/harvester/core/management/base.py
+++ b/harvester/core/management/base.py
@@ -1,14 +1,10 @@
 from tqdm import tqdm
-import logging
 from mimetypes import guess_type
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from core.utils.language import get_language_from_snippet
-
-
-logger = logging.getLogger("harvester")
 
 
 class HarvesterCommand(BaseCommand):

--- a/harvester/core/management/base.py
+++ b/harvester/core/management/base.py
@@ -1,12 +1,9 @@
-import json
-from copy import copy
 from tqdm import tqdm
 import logging
 from mimetypes import guess_type
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
 from core.utils.language import get_language_from_snippet
 
@@ -20,52 +17,13 @@ class HarvesterCommand(BaseCommand):
     """
 
     show_progress = True
-    use_logger = True
 
     def add_arguments(self, parser):
         parser.add_argument('-n', '--no-progress', action="store_true")
-        parser.add_argument('-L', '--no-logger', action="store_false")
 
     def execute(self, *args, **options):
         self.show_progress = not options.get("no_progress", False)
-        self.use_logger = options.get("no_logger", True)
         super().execute(*args, **options)
-
-    def error(self, message):
-        if self.use_logger:
-            logger.error(message)
-        self.stderr.write(self.style.ERROR(message))
-
-    def warning(self, message):
-        if self.use_logger:
-            logger.warning(message)
-        self.stderr.write(self.style.WARNING(message))
-
-    def info(self, message, object=None, log=False):
-        if self.use_logger:
-            extra = {"extra": object} if object is not None else {}
-            logger.info(message, extra=extra)
-        if object is not None:
-            message += " " + json.dumps(object, indent=4)
-        self.stdout.write(message)
-
-    def success(self, message):
-        self.stdout.write(self.style.SUCCESS(message))
-
-    def header(self, header, options=None):
-        self.info("")
-        self.info("")
-        self.info(header)
-        self.info("-" * len(header))
-        if options:
-            opts = copy(options)
-            opts.pop("stdout", None)
-            opts.pop("stderr", None)
-            self.info("Options: ", opts)
-        self.info("Commit: {}".format(settings.GIT_COMMIT))
-        now = timezone.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.info("Time: {}".format(now))
-        self.info("")
 
     def progress(self, iterator, total=None):
         if not self.show_progress:

--- a/harvester/core/management/commands/generate_previews.py
+++ b/harvester/core/management/commands/generate_previews.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 from core.constants import HarvestStages
 from core.models import Document, OAIPMHHarvest
 from harvester.tasks import generate_browser_preview, generate_pdf_preview, generate_youtube_preview
+from harvester import logger
 
 
 class Command(HarvesterCommand):
@@ -22,18 +23,19 @@ class Command(HarvesterCommand):
             Q(properties__file_type="pdf")
         ).filter(dataset__name=dataset_name).filter(properties__preview_path=None)
         signatures = self.create_task_signatures(html_documents)
+
+        logger.info(f"Started {len(signatures)} tasks to generate previews", dataset=dataset_name)
         self.run_jobs_in_group(signatures)
+
         self.complete_preview_stage(dataset_name)
+        logger.info("Done generating previews", dataset=dataset_name)
 
     def run_jobs_in_group(self, signatures):
-        self.info(f"Started {len(signatures)} tasks to generate previews")
         job = group(signatures)
         result = job.apply_async()
 
         while not result.ready():
             time.sleep(10)
-
-        self.info("Done generating previews")
 
     def create_task_signatures(self, documents):
         return [self.determine_task_signature(document) for document in documents]

--- a/harvester/core/models/datatypes/arrangement.py
+++ b/harvester/core/models/datatypes/arrangement.py
@@ -1,4 +1,3 @@
-import logging
 from collections import Iterator, defaultdict
 from zipfile import BadZipFile
 from bs4 import BeautifulSoup
@@ -15,9 +14,7 @@ from datagrowth import settings as datagrowth_settings
 from datagrowth.datatypes import CollectionBase, DocumentCollectionMixin
 from datagrowth.utils import ibatch
 from core.models import CommonCartridge, FileResource
-
-
-log = logging.getLogger("harvester")
+from harvester import logger
 
 
 class Arrangement(DocumentCollectionMixin, CollectionBase):
@@ -171,7 +168,7 @@ class Arrangement(DocumentCollectionMixin, CollectionBase):
             cc.clean()
             package_content = cc.list_content_by_title()
         except (ValidationError, BadZipFile):
-            log.warning(f"Invalid or missing common cartridge for file resource: {package_file.id}")
+            logger.warning(f"Invalid or missing common cartridge for file resource: {package_file.id}")
             return []
 
         # Combine the links and content into documents we may search for

--- a/harvester/core/models/resources/basic.py
+++ b/harvester/core/models/resources/basic.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import json
 from urllib.parse import quote_plus
@@ -10,9 +9,9 @@ from urlobject import URLObject
 from django.conf import settings
 from django.db import models
 from datagrowth.resources import HttpFileResource, TikaResource as DGTikaResource, file_resource_delete_handler
+from harvester import logger
 
 
-logger = logging.getLogger("harvester")
 s3_client = boto3.client("s3")
 
 

--- a/harvester/core/tests/commands/harvest_basic_content.py
+++ b/harvester/core/tests/commands/harvest_basic_content.py
@@ -1,5 +1,4 @@
 import os
-import logging
 from unittest.mock import patch
 from io import StringIO
 from datetime import datetime
@@ -68,12 +67,6 @@ class TestBasicHarvest(TestCase):
 
     fixtures = ["datasets-new", "surf-oaipmh-1970-01-01", "resources"]
 
-    def setUp(self):
-        logging.disable(logging.CRITICAL)
-
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
-
     def get_command_instance(self):
         command = BasicHarvestCommand()
         command.show_progress = False
@@ -89,7 +82,7 @@ class TestBasicHarvest(TestCase):
         # After that the heavy lifting is done by two methods named download_seed_files and extract_from_seed_files.
         # We'll test those separately, but check if they get called with the seeds returned by get_edurep_oaipmh_seeds
         out = StringIO()
-        call_command("harvest_basic_content", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+        call_command("harvest_basic_content", "--dataset=test", "--no-progress", stdout=out)
         # Asserting usage of get_edurep_oaipmh_seeds
         seeds_target.assert_called_once_with(
             "surf", make_aware(datetime(year=1970, month=1, day=1)),
@@ -118,7 +111,7 @@ class TestBasicHarvest(TestCase):
     def test_harvest_with_youtube(self, seeds_mock):
         out = StringIO()
         with patch(SEND_SERIE_TARGET, return_value=[[12024, 12025], []]) as send_serie_mock:
-            call_command("harvest_basic_content", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+            call_command("harvest_basic_content", "--dataset=test", "--no-progress", stdout=out)
         self.assertEqual(send_serie_mock.call_count, 4, "Expects two calls to send_serie")
 
         for name, args, kwargs in send_serie_mock.mock_calls[0:2]:  # Youtube

--- a/harvester/core/tests/commands/harvest_basic_content.py
+++ b/harvester/core/tests/commands/harvest_basic_content.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from unittest.mock import patch
 from io import StringIO
 from datetime import datetime
@@ -67,6 +68,12 @@ class TestBasicHarvest(TestCase):
 
     fixtures = ["datasets-new", "surf-oaipmh-1970-01-01", "resources"]
 
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
     def get_command_instance(self):
         command = BasicHarvestCommand()
         command.show_progress = False
@@ -89,9 +96,9 @@ class TestBasicHarvest(TestCase):
             include_deleted=False
         )
         # Asserting usage of download_seed_files
-        download_target.assert_called_once_with(DOWNLOAD_ALLOWED_DUMMY_SEEDS)
+        download_target.assert_called_once_with(DOWNLOAD_ALLOWED_DUMMY_SEEDS, dataset='test')
         # And then usage of extract_from_seeds
-        extract_target.assert_called_once_with(DOWNLOAD_ALLOWED_DUMMY_SEEDS, [1])
+        extract_target.assert_called_once_with(DOWNLOAD_ALLOWED_DUMMY_SEEDS, [1], dataset='test')
         # Last but not least we check that the correct EdurepHarvest objects have indeed progressed
         # to prevent repetitious harvests.
         surf_harvest = OAIPMHHarvest.objects.get(source__spec="surf")

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -71,7 +71,7 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         call_command("push_es_index", "--dataset=test", "--no-progress", "--promote")
 
         # Expect command to print what actions it will undertake and since what modification date
-        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", "ASSERT", dataset='test')
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
         # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
         # Expect command to print how many English documents it encountered

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -7,7 +7,6 @@ to update the indices.
 """
 
 from unittest.mock import patch
-from io import StringIO
 
 from django.utils.timezone import make_aware, datetime
 from django.test import TestCase
@@ -55,7 +54,8 @@ class TestPushToIndex(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_with_promote(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_with_promote(self, info_logger, streaming_bulk, get_es_client):
 
         # Setting basic expectations used in the test
         expected_doc_count = {
@@ -68,23 +68,13 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger")
 
-        # Asserting output of command
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:2020-02-10, recreate:False and promote:True",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        # Asserting logging of command
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 2,
@@ -112,7 +102,8 @@ class TestPushToIndex(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_without_promote(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_without_promote(self, info_logger, streaming_bulk, get_es_client):
 
         # Setting basic expectations used in the test
         expected_doc_count = {
@@ -125,23 +116,13 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
 
-        # Asserting output of command
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:2020-02-10, recreate:False and promote:False",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        # Asserting logging of command
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 2,
@@ -199,7 +180,8 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_deletes(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_deletes(self, info_logger, streaming_bulk, get_es_client):
 
         # Marking the Wikiwijsmaken packages as deleted to see how that propagates
         arrangement = Arrangement.objects.get(id=92378)
@@ -222,23 +204,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         ]
 
         # Calling command and catching output for some checks
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
 
-        # Asserting output of command
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:2020-02-10, recreate:False and promote:False",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        # Asserting logging of command
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 2,
@@ -262,7 +234,8 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_delta(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_delta(self, info_logger, streaming_bulk, get_es_client):
 
         # Putting latest harvest into the future to test partial update
         harvested_at = make_aware(datetime(year=2020, month=6, day=1))
@@ -275,22 +248,12 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks similar to TestPushToIndex.test_edurep_surf_with_promote
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
         # Asserting output
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:2020-06-01, recreate:False and promote:False",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        info_logger.assert_any_call("since:2020-06-01, recreate:False and promote:False", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 2,
@@ -311,7 +274,8 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_recreate(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_recreate(self, info_logger, streaming_bulk, get_es_client):
 
         # Setting basic expectations used in the test
         expected_doc_count = {
@@ -325,23 +289,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         get_es_client.reset_mock()
 
         # Calling command and catching output for some checks
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--recreate", "--no-progress", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--recreate", "--no-progress", "--no-logger")
 
         # Asserting output of command
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:1970-01-01, recreate:True and promote:False",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        info_logger.assert_any_call("since:1970-01-01, recreate:True and promote:False", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 2,
@@ -375,7 +329,8 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
 
     @patch("core.models.search.get_es_client", return_value=elastic_client)
     @patch("core.models.search.streaming_bulk")
-    def test_edurep_surf_with_promote(self, streaming_bulk, get_es_client):
+    @patch("harvester.logger.info")
+    def test_edurep_surf_with_promote(self, info_logger, streaming_bulk, get_es_client):
 
         # Setting basic expectations used in the test
         expected_doc_count = {
@@ -388,23 +343,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        out = StringIO()
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger", stdout=out)
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger")
 
-        # Asserting output of command
-        stdout = out.getvalue().split("\n")
-        results = [rsl for rsl in stdout if rsl]
-        self.assertIn(
-            "since:2020-02-10, recreate:False and promote:True",
-            results,
-            "Expected command to print what actions it will undertake and since what modification date"
-        )
-        self.assertIn(f"nl:{expected_doc_count['nl']}", results,
-                      "Expected command to print how many Dutch documents it encountered")
-        self.assertIn(f"en:{expected_doc_count['en']}", results,
-                      "Expected command to print how many English documents it encountered")
-        self.assertIn("unk:1", results,
-                      "Expected command to print how many documents it encountered with unknown language")
+        # Asserting logging of command
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
+        info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
         self.assertEqual(get_es_client.call_count, 4,

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -70,10 +70,13 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         # Calling command and catching output for some checks
         call_command("push_es_index", "--dataset=test", "--no-progress", "--promote")
 
-        # Asserting logging of command
-        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
+        # Expect command to print what actions it will undertake and since what modification date
+        info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", "ASSERT", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
@@ -118,10 +121,13 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         # Calling command and catching output for some checks
         call_command("push_es_index", "--dataset=test", "--no-progress")
 
-        # Asserting logging of command
+        # Expect command to print what actions it will undertake and since what modification date
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
@@ -206,10 +212,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         # Calling command and catching output for some checks
         call_command("push_es_index", "--dataset=test", "--no-progress")
 
-        # Asserting logging of command
+        # Expect command to print what actions it will undertake and since what modification date
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
@@ -249,10 +258,14 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
 
         # Calling command and catching output for some checks similar to TestPushToIndex.test_edurep_surf_with_promote
         call_command("push_es_index", "--dataset=test", "--no-progress")
-        # Asserting output
+
+        # Expect command to print what actions it will undertake and since what modification date
         info_logger.assert_any_call("since:2020-06-01, recreate:False and promote:False", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
@@ -291,10 +304,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         # Calling command and catching output for some checks
         call_command("push_es_index", "--dataset=test", "--recreate", "--no-progress")
 
-        # Asserting output of command
+        # Expect command to print what actions it will undertake and since what modification date
         info_logger.assert_any_call("since:1970-01-01, recreate:True and promote:False", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library
@@ -345,10 +361,13 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         # Calling command and catching output for some checks
         call_command("push_es_index", "--dataset=test", "--no-progress", "--promote")
 
-        # Asserting logging of command
+        # Expect command to print what actions it will undertake and since what modification date
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
+        # Expect command to print how many Dutch documents it encountered
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
+        # Expect command to print how many English documents it encountered
         info_logger.assert_any_call(f"en:{expected_doc_count['en']}", dataset='test')
+        # Expect command to print how many documents it encountered with unknown language
         info_logger.assert_any_call("unk:1", dataset='test')
 
         # Asserting calls to Elastic Search library

--- a/harvester/core/tests/commands/push_es_index.py
+++ b/harvester/core/tests/commands/push_es_index.py
@@ -68,7 +68,7 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote")
 
         # Asserting logging of command
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')
@@ -116,7 +116,7 @@ class TestPushToIndex(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--no-progress")
 
         # Asserting logging of command
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
@@ -146,7 +146,7 @@ class TestPushToIndex(ElasticSearchClientTestCase):
     def test_invalid_dataset(self):
         # Testing the case where a Dataset does not exist at all
         try:
-            call_command("push_es_index", "--dataset=invalid", "--no-logger")
+            call_command("push_es_index", "--dataset=invalid")
             self.fail("push_es_index did not raise for an invalid dataset")
         except Dataset.DoesNotExist:
             pass
@@ -204,7 +204,7 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         ]
 
         # Calling command and catching output for some checks
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--no-progress")
 
         # Asserting logging of command
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:False", dataset='test')
@@ -248,7 +248,7 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks similar to TestPushToIndex.test_edurep_surf_with_promote
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--no-progress")
         # Asserting output
         info_logger.assert_any_call("since:2020-06-01, recreate:False and promote:False", dataset='test')
         info_logger.assert_any_call(f"nl:{expected_doc_count['nl']}", dataset='test')
@@ -289,7 +289,7 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         get_es_client.reset_mock()
 
         # Calling command and catching output for some checks
-        call_command("push_es_index", "--dataset=test", "--recreate", "--no-progress", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--recreate", "--no-progress")
 
         # Asserting output of command
         info_logger.assert_any_call("since:1970-01-01, recreate:True and promote:False", dataset='test')
@@ -343,7 +343,7 @@ class TestPushToIndexWithHistory(ElasticSearchClientTestCase):
         }
 
         # Calling command and catching output for some checks
-        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote", "--no-logger")
+        call_command("push_es_index", "--dataset=test", "--no-progress", "--promote")
 
         # Asserting logging of command
         info_logger.assert_any_call("since:2020-02-10, recreate:False and promote:True", dataset='test')

--- a/harvester/core/tests/commands/test_generate_previews.py
+++ b/harvester/core/tests/commands/test_generate_previews.py
@@ -1,4 +1,3 @@
-from io import StringIO
 from unittest.mock import patch, Mock
 
 from django.test import TestCase
@@ -24,7 +23,6 @@ class TestGeneratePreviews(TestCase):
         ready_mock = Mock()
         ready_mock.return_value = True
         apply_async_mock.return_value.ready = ready_mock
-        out = StringIO()
         dataset = DatasetFactory.create(name="test")
         oaipmh_harvest = OAIPMHHarvestFactory.create(dataset=dataset, stage=HarvestStages.PREVIEW)
         document_with_website = DocumentFactory.create(dataset=dataset, mime_type="text/html")
@@ -33,9 +31,7 @@ class TestGeneratePreviews(TestCase):
         DocumentFactory.create(dataset=dataset, mime_type="foo/bar")
         DocumentFactory.create(dataset=dataset, mime_type="text/html", preview_path="previews/8")
 
-        call_command(
-            "generate_previews", f"--dataset={dataset.name}", "--no-progress", "--no-logger", stdout=out
-        )
+        call_command("generate_previews", f"--dataset={dataset.name}", "--no-progress")
 
         preview_task_mock.assert_called_once_with(document_with_website.id)
         youtube_task_mock.assert_called_once_with(document_from_youtube.id)

--- a/harvester/core/tests/commands/update_dataset.py
+++ b/harvester/core/tests/commands/update_dataset.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from io import StringIO
 from datetime import datetime
-import logging
 
 from django.test import TestCase
 from django.core.management import call_command
@@ -34,15 +33,7 @@ DUMMY_SEEDS = [
 ]
 
 
-class TestCaseWithoutLogging(TestCase):
-    def setUp(self):
-        logging.disable(logging.CRITICAL)
-
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
-
-
-class TestCreateOrUpdateDatasetNoHistory(TestCaseWithoutLogging):
+class TestCreateOrUpdateDatasetNoHistory(TestCase):
 
     fixtures = ["datasets-new", "surf-oaipmh-1970-01-01", "resources"]
 
@@ -70,7 +61,7 @@ class TestCreateOrUpdateDatasetNoHistory(TestCaseWithoutLogging):
         # handle_upsert_seeds and handle_deletion_seeds.
         # We'll test those separately, but check if they get called with the seeds returned by get_edurep_oaipmh_seeds
         out = StringIO()
-        call_command("update_dataset", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+        call_command("update_dataset", "--dataset=test", "--no-progress", stdout=out)
         # Asserting usage of get_edurep_oaipmh_seeds
         seeds_target.assert_called_once_with("surf", make_aware(datetime(year=1970, month=1, day=1)))
         # Asserting usage of handle_upsert_seeds
@@ -165,7 +156,7 @@ class TestCreateOrUpdateDatasetNoHistory(TestCaseWithoutLogging):
         self.assertEqual(collection.arrangement_set.count(), 0)
 
 
-class TestCreateOrUpdateDatasetWithHistory(TestCaseWithoutLogging):
+class TestCreateOrUpdateDatasetWithHistory(TestCase):
 
     fixtures = ["datasets-history", "surf-oaipmh-2020-01-01", "resources"]
 

--- a/harvester/core/tests/commands/update_dataset.py
+++ b/harvester/core/tests/commands/update_dataset.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from io import StringIO
 from datetime import datetime
+import logging
 
 from django.test import TestCase
 from django.core.management import call_command
@@ -33,7 +34,15 @@ DUMMY_SEEDS = [
 ]
 
 
-class TestCreateOrUpdateDatasetNoHistory(TestCase):
+class TestCaseWithoutLogging(TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+
+class TestCreateOrUpdateDatasetNoHistory(TestCaseWithoutLogging):
 
     fixtures = ["datasets-new", "surf-oaipmh-1970-01-01", "resources"]
 
@@ -43,6 +52,7 @@ class TestCreateOrUpdateDatasetNoHistory(TestCase):
         # The only valid stage for "update_dataset" to act on.
         OAIPMHHarvest.objects.filter(stage=HarvestStages.VIDEO).update(stage=HarvestStages.COMPLETE)
         OAIPMHHarvest.objects.filter(source__spec="surf").update(stage=HarvestStages.VIDEO)
+        super().setUp()
 
     def get_command_instance(self):
         command = DatasetCommand()
@@ -155,7 +165,7 @@ class TestCreateOrUpdateDatasetNoHistory(TestCase):
         self.assertEqual(collection.arrangement_set.count(), 0)
 
 
-class TestCreateOrUpdateDatasetWithHistory(TestCase):
+class TestCreateOrUpdateDatasetWithHistory(TestCaseWithoutLogging):
 
     fixtures = ["datasets-history", "surf-oaipmh-2020-01-01", "resources"]
 
@@ -163,6 +173,7 @@ class TestCreateOrUpdateDatasetWithHistory(TestCase):
         # Setting the stage of the "surf" set harvests to VIDEO.
         # The only valid stage for "update_dataset" to act on.
         OAIPMHHarvest.objects.filter(source__spec="surf").update(stage=HarvestStages.VIDEO)
+        super().setUp()
 
     def get_command_instance(self):
         command = DatasetCommand()

--- a/harvester/edurep/tests/commands/harvest_edurep_seeds.py
+++ b/harvester/edurep/tests/commands/harvest_edurep_seeds.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 from io import StringIO
-import logging
 from datetime import datetime
 
 from django.test import TestCase
@@ -12,15 +11,7 @@ from core.models import Arrangement, Document, OAIPMHHarvest
 from core.constants import HarvestStages
 
 
-class TestCaseWithoutLogging(TestCase):
-    def setUp(self):
-        logging.disable(logging.CRITICAL)
-
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
-
-
-class TestSeedHarvest(TestCaseWithoutLogging):
+class TestSeedHarvest(TestCase):
     """
     This test case represents the scenario where a harvest is started from t=0
     """
@@ -34,7 +25,7 @@ class TestSeedHarvest(TestCaseWithoutLogging):
         # This makes sure that a lot of edge cases will be covered like HTTP errors.
         out = StringIO()
         with patch("edurep.management.commands.harvest_edurep_seeds.send", wraps=send) as send_mock:
-            call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+            call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", stdout=out)
         # Asserting main result (ignoring any white lines at the end of output)
         stdout = out.getvalue().split("\n")
         stdout.reverse()
@@ -67,7 +58,7 @@ class TestSeedHarvest(TestCaseWithoutLogging):
     def test_edurep_invalid_dataset(self):
         # Testing the case where a Dataset does not exist at all
         try:
-            call_command("harvest_edurep_seeds", "--dataset=invalid", "--no-logger")
+            call_command("harvest_edurep_seeds", "--dataset=invalid")
             self.fail("harvest_edurep_seeds did not raise for an invalid dataset")
         except OAIPMHHarvest.DoesNotExist:
             pass
@@ -76,7 +67,7 @@ class TestSeedHarvest(TestCaseWithoutLogging):
         surf_harvest.stage = HarvestStages.COMPLETE
         surf_harvest.save()
         try:
-            call_command("harvest_edurep_seeds", "--dataset=invalid", "--no-logger")
+            call_command("harvest_edurep_seeds", "--dataset=invalid")
             self.fail("harvest_edurep_seeds did not raise for a dataset without pending harvests")
         except OAIPMHHarvest.DoesNotExist:
             pass
@@ -85,13 +76,13 @@ class TestSeedHarvest(TestCaseWithoutLogging):
         out = StringIO()
         with patch("edurep.management.commands.harvest_edurep_seeds.send", return_value=([], [100],)):
             try:
-                call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+                call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", stdout=out)
                 self.fail("harvest_edurep_seeds did not fail when EdurepOAIPMH was returning errors")
             except CommandError:
                 pass
 
 
-class TestSeedHarvestWithHistory(TestCaseWithoutLogging):
+class TestSeedHarvestWithHistory(TestCase):
     """
     This test case represents the scenario where a harvest from a previous harvest
     """
@@ -105,7 +96,7 @@ class TestSeedHarvestWithHistory(TestCaseWithoutLogging):
         # This makes sure that a lot of edge cases will be covered like HTTP errors.
         out = StringIO()
         with patch("edurep.management.commands.harvest_edurep_seeds.send", wraps=send) as send_mock:
-            call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", "--no-logger", stdout=out)
+            call_command("harvest_edurep_seeds", "--dataset=test", "--no-progress", stdout=out)
         # Asserting main result (ignoring any white lines at the end of output)
         stdout = out.getvalue().split("\n")
         stdout.reverse()

--- a/harvester/edurep/tests/commands/harvest_edurep_seeds.py
+++ b/harvester/edurep/tests/commands/harvest_edurep_seeds.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from io import StringIO
+import logging
 from datetime import datetime
 
 from django.test import TestCase
@@ -11,7 +12,15 @@ from core.models import Arrangement, Document, OAIPMHHarvest
 from core.constants import HarvestStages
 
 
-class TestSeedHarvest(TestCase):
+class TestCaseWithoutLogging(TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+
+class TestSeedHarvest(TestCaseWithoutLogging):
     """
     This test case represents the scenario where a harvest is started from t=0
     """
@@ -82,7 +91,7 @@ class TestSeedHarvest(TestCase):
                 pass
 
 
-class TestSeedHarvestWithHistory(TestCase):
+class TestSeedHarvestWithHistory(TestCaseWithoutLogging):
     """
     This test case represents the scenario where a harvest from a previous harvest
     """

--- a/harvester/edurep/utils.py
+++ b/harvester/edurep/utils.py
@@ -1,4 +1,3 @@
-import logging
 from urlobject import URLObject
 
 from datagrowth.configuration import create_config
@@ -6,6 +5,7 @@ from datagrowth.processors import ExtractProcessor
 
 from edurep.models import EdurepOAIPMH
 from edurep.extraction import EdurepDataExtraction
+from harvester import logger
 
 
 EDUREP_EXTRACTION_OBJECTIVE = {
@@ -33,9 +33,6 @@ EDUREP_EXTRACTION_OBJECTIVE = {
 }
 
 
-err = logging.getLogger(__file__)
-
-
 def get_edurep_oaipmh_seeds(set_specification, latest_update, include_deleted=True):
     queryset = EdurepOAIPMH.objects\
         .filter(set_specification=set_specification, since__date__gte=latest_update.date(), status=200)
@@ -56,7 +53,7 @@ def get_edurep_oaipmh_seeds(set_specification, latest_update, include_deleted=Tr
         try:
             results += list(prc.extract_from_resource(harvest))
         except ValueError as exc:
-            err.warning("Invalid XML:", exc, harvest.uri)
+            logger.warning("Invalid XML:", exc, harvest.uri)
     seeds = []
     for seed in results:
         # Some records in Edurep do not have any known URL

--- a/harvester/harvester/logger.py
+++ b/harvester/harvester/logger.py
@@ -1,0 +1,21 @@
+import django_log_formatter_json
+import logging
+
+
+logger = logging.getLogger('harvester')
+
+
+def _convert_to_extra_field(level=None, **kwargs):
+    extra = kwargs
+    extra['level'] = level
+    return extra
+
+
+def debug(message, **kwargs):
+    extra = _convert_to_extra_field(level='DEBUG', **kwargs)
+    logger.debug(message, extra=extra)
+
+
+def info(message, **kwargs):
+    extra = _convert_to_extra_field(level='INFO', **kwargs)
+    logger.info(message, extra=extra)

--- a/harvester/harvester/logger.py
+++ b/harvester/harvester/logger.py
@@ -22,3 +22,8 @@ def info(message, *args, **kwargs):
 def warning(message, *args, **kwargs):
     extra = _convert_to_extra_field(level='WARNING', **kwargs)
     logger.warning(message, *args, extra=extra)
+
+
+def error(message, *args, **kwargs):
+    extra = _convert_to_extra_field(level='ERROR', **kwargs)
+    logger.error(message, *args, extra=extra)

--- a/harvester/harvester/logger.py
+++ b/harvester/harvester/logger.py
@@ -1,6 +1,4 @@
-import django_log_formatter_json
 import logging
-
 
 logger = logging.getLogger('harvester')
 
@@ -11,11 +9,16 @@ def _convert_to_extra_field(level=None, **kwargs):
     return extra
 
 
-def debug(message, **kwargs):
+def debug(message, *args, **kwargs):
     extra = _convert_to_extra_field(level='DEBUG', **kwargs)
-    logger.debug(message, extra=extra)
+    logger.debug(message, *args, extra=extra)
 
 
-def info(message, **kwargs):
+def info(message, *args, **kwargs):
     extra = _convert_to_extra_field(level='INFO', **kwargs)
-    logger.info(message, extra=extra)
+    logger.info(message, *args, extra=extra)
+
+
+def warning(message, *args, **kwargs):
+    extra = _convert_to_extra_field(level='WARNING', **kwargs)
+    logger.warning(message, *args, extra=extra)

--- a/harvester/harvester/management/commands/load_harvester_data.py
+++ b/harvester/harvester/management/commands/load_harvester_data.py
@@ -10,6 +10,7 @@ from django.db import models, connection
 from datagrowth.utils import get_dumps_path, objects_from_disk
 from surfpol.configuration import create_configuration
 from harvester.settings import environment
+from harvester import logger
 from core.management.base import HarvesterCommand
 from core.models import Dataset, ElasticIndex, FileResource
 from core.models.resources.basic import file_resource_delete_handler
@@ -78,7 +79,7 @@ class Command(base.LabelCommand, HarvesterCommand):
             dataset.delete()
 
         if harvest_source and not skip_download:
-            self.info(f"Downloading dump file for: {dataset_label}")
+            logger.info(f"Downloading dump file for: {dataset_label}", dataset=dataset_label)
             ctx = Context(environment)
             harvester_data_bucket = f"s3://{source_environment.aws.harvest_content_bucket}/datasets/harvester"
             ctx.run(f"aws s3 sync {harvester_data_bucket} {settings.DATAGROWTH_DATA_DIR}")

--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -183,7 +183,7 @@ REST_FRAMEWORK = {
 # https://docs.sentry.io/
 
 TESTING = sys.argv[1:2] == ['test']
-log_handlers = ['console', 'json'] if not TESTING else []
+log_handlers = [environment.django.logging.handler] if not TESTING else []
 log_level = environment.django.logging.level if not TESTING else 'CRITICAL'
 
 LOGGING = {
@@ -200,8 +200,7 @@ LOGGING = {
     'handlers': {
         'json': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': 'logs/harvester.log.json',
+            'class': 'logging.StreamHandler',
             'formatter': 'json'
         },
         'console': {

--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -200,7 +200,7 @@ LOGGING = {
     'loggers': {
         'harvester': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': f"{environment.django.logging.level}",
             'propagate': True,
         },
     },

--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -182,25 +182,38 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/2.2/topics/logging/
 # https://docs.sentry.io/
 
+TESTING = sys.argv[1:2] == ['test']
+log_handlers = ['console', 'json'] if not TESTING else []
+log_level = environment.django.logging.level if not TESTING else 'CRITICAL'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
         'json': {
             '()': 'django_log_formatter_json.JSONFormatter',
+        },
+        'standard': {
+            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
         }
     },
     'handlers': {
+        'json': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': 'logs/harvester.log.json',
+            'formatter': 'json'
+        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'json'
-        },
+            'formatter': 'standard'
+        }
     },
     'loggers': {
         'harvester': {
-            'handlers': ['console'],
-            'level': f"{environment.django.logging.level}",
+            'handlers': log_handlers,
+            'level': log_level,
             'propagate': True,
         },
     },

--- a/harvester/harvester/settings.py
+++ b/harvester/harvester/settings.py
@@ -182,9 +182,9 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/2.2/topics/logging/
 # https://docs.sentry.io/
 
-TESTING = sys.argv[1:2] == ['test']
-log_handlers = [environment.django.logging.handler] if not TESTING else []
-log_level = environment.django.logging.level if not TESTING else 'CRITICAL'
+_logging_enabled = sys.argv[1:2] != ['test']
+log_handlers = [environment.django.logging.handler] if _logging_enabled else []
+log_level = environment.django.logging.level if _logging_enabled else 'CRITICAL'
 
 LOGGING = {
     'version': 1,

--- a/harvester/harvester/tasks/background.py
+++ b/harvester/harvester/tasks/background.py
@@ -1,4 +1,3 @@
-import logging
 from invoke import Context
 
 from django.conf import settings
@@ -9,14 +8,12 @@ from harvester.celery import app
 from core.models import Dataset, OAIPMHHarvest
 from core.constants import HarvestStages
 from edurep.models import EdurepOAIPMH
-
-
-log = logging.getLogger("harvester")
+from harvester import logger
 
 
 @app.task(name="health_check")
 def health_check():
-    log.info(f"Healthy: {environment.django.domain}")
+    logger.info(f"Healthy: {environment.django.domain}")
 
 
 @app.task(name="harvest")

--- a/harvester/task-container-definitions.json
+++ b/harvester/task-container-definitions.json
@@ -1,5 +1,29 @@
 [
   {
+    "essential": true,
+    "image": "906394416424.dkr.ecr.eu-central-1.amazonaws.com/aws-for-fluent-bit:latest",
+    "name": "log_router",
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::${harvester_bucket}/fluent.conf"
+      }
+    },
+    "environment": [
+      { "name" : "VERSION", "value" : "${version}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "firelens-container",
+        "awslogs-region": "eu-central-1",
+        "awslogs-stream-prefix": "firelens"
+      }
+    },
+    "memoryReservation": 50
+  },
+  {
     "name": "harvester-container",
     "image": "${REPOSITORY}/harvester:${version}",
     "cpu": 0,
@@ -16,13 +40,7 @@
       { "name" : "APPLICATION_MODE", "value" : "${mode}" }
     ],
     "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "/ecs/harvester",
-        "awslogs-region": "eu-central-1",
-        "awslogs-stream-prefix": "harvester-${version}",
-        "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-      }
+      "logDriver": "awsfirelens"
     }
   }
 ]

--- a/harvester/task-with-workers-container-definitions.json
+++ b/harvester/task-with-workers-container-definitions.json
@@ -1,5 +1,29 @@
 [
   {
+    "essential": true,
+    "image": "906394416424.dkr.ecr.eu-central-1.amazonaws.com/aws-for-fluent-bit:latest",
+    "name": "log_router",
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::${harvester_bucket}/fluent.conf"
+      }
+    },
+    "environment": [
+      { "name" : "VERSION", "value" : "${version}" }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "firelens-container",
+        "awslogs-region": "eu-central-1",
+        "awslogs-stream-prefix": "firelens"
+      }
+    },
+    "memoryReservation": 50
+  },
+  {
     "name": "harvester-container",
     "image": "${REPOSITORY}/harvester:${version}",
     "cpu": 0,
@@ -16,13 +40,7 @@
       { "name" : "APPLICATION_MODE", "value" : "${mode}" }
     ],
     "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "/ecs/harvester",
-        "awslogs-region": "eu-central-1",
-        "awslogs-stream-prefix": "harvester-${version}",
-        "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-      }
+      "logDriver": "awsfirelens"
     }
   },
   {
@@ -36,13 +54,7 @@
       { "name" : "APPLICATION_MODE", "value" : "${mode}" }
     ],
     "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "/ecs/harvester",
-        "awslogs-region": "eu-central-1",
-        "awslogs-stream-prefix": "celery-worker-${version}",
-        "awslogs-multiline-pattern": "^\\[?\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d \\d\\d:\\d\\d:\\d\\d,\\d\\d\\d"
-      }
+      "logDriver": "awsfirelens"
     }
   }
 ]


### PR DESCRIPTION
Adds a logger. This logger sends log messages to the console on localhost or in JSON format on AWS. On AWS the logs are sent to Firelens which uses fluent-bit. Fluent-bit does some small transformations on the data and subsequently sends it to both Elasticsearch and Cloudwatch. See terraform PR for more details.

The logging could possibly be improved a bit more, but making it work on AWS did (of course) take a lot more time than anticipated 😓 . We can do these improvements at a later time.

Terraform PR: https://github.com/surfedushare/infra/pull/32

PS: this merges into the previews branch