### PR TITLE
Fix searching for publisher and keywords

### DIFF
--- a/environments/surfpol/configuration.py
+++ b/environments/surfpol/configuration.py
@@ -194,7 +194,13 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                     }
                 },
                 'publishers': {
-                    'type': 'keyword'
+                    'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'type': 'keyword',
+                            'ignore_above': 256
+                        }
+                    }
                 },
                 'publisher_date': {
                     'type': 'date',
@@ -204,7 +210,13 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                     'type': 'keyword'
                 },
                 'keywords': {
-                    'type': 'keyword'
+                    'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'type': 'keyword',
+                            'ignore_above': 256
+                        }
+                    }
                 },
                 'file_type': {
                     'type': 'keyword'

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -459,5 +459,5 @@ class ElasticSearchApiClient:
         elif external_id == 'lom.general.aggregationlevel':
             return 'aggregation_level'
         elif external_id == 'lom.lifecycle.contribute.publisher':
-            return 'publishers'
+            return 'publishers.keyword'
         return external_id


### PR DESCRIPTION
Adjusts the mapping to be able to search for publisher and keywords.

For example now returns results when keyword is `#hbovpk` and your search query is `hbovpk`.