### PR TITLE
Fix difference in search results with uppercase/lowercase

### DIFF
--- a/environments/surfpol/configuration.py
+++ b/environments/surfpol/configuration.py
@@ -262,7 +262,7 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
         configuration["settings"]["analysis"]["analyzer"]["dutch_dictionary_decompound"] = {
             "type": "custom",
             "tokenizer": "standard",
-            "filter": ["dutch_stop", "dictionary_decompound"]
+            "filter": ["lowercase", "dutch_stop", "dictionary_decompound"]
         }
         configuration["settings"]["analysis"]["filter"]["dictionary_decompound"] = {
             "type": "dictionary_decompounder",

--- a/service/surf/vendor/search/tests/tests_elastic_search.py
+++ b/service/surf/vendor/search/tests/tests_elastic_search.py
@@ -386,6 +386,7 @@ class TestsElasticSearch(BaseElasticSearchTestCase):
             'type': 'custom',
             'tokenizer': 'standard',
             'filter': [
+                'lowercase',
                 'dutch_stop',
                 'dictionary_decompound'
             ]


### PR DESCRIPTION
For example 'Vrije' was split up in 'rij' and 'rije' and 'vrije' was split up in 'vrij', 'rij', 'rije', 'vrije'.
Now the search terms are first made lowercase before splitting up and now the number of search results is identical regardless of using uppercase or lowercase 👍 .
