### PR TITLE
Search folding

### DIFF
--- a/environments/surfpol/configuration.py
+++ b/environments/surfpol/configuration.py
@@ -165,9 +165,12 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
             'properties': {
                 'title': {
                     'type': 'text',
-                    'analyzer': analyzer,
-                    'search_analyzer': search_analyzer,
                     'fields': {
+                        'analyzed': {
+                            'type': 'text',
+                            'analyzer': analyzer,
+                            'search_analyzer': search_analyzer,
+                        },
                         'folded': {
                             'type': 'text',
                             'analyzer': 'folding'
@@ -176,9 +179,12 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                 },
                 'text': {
                     'type': 'text',
-                    'analyzer': analyzer,
-                    'search_analyzer': search_analyzer,
                     'fields': {
+                        'analyzed': {
+                            'type': 'text',
+                            'analyzer': analyzer,
+                            'search_analyzer': search_analyzer,
+                        },
                         'folded': {
                             'type': 'text',
                             'analyzer': 'folding'
@@ -187,9 +193,12 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                 },
                 'transcription': {
                     'type': 'text',
-                    'analyzer': analyzer,
-                    'search_analyzer': search_analyzer,
                     'fields': {
+                        'analyzed': {
+                            'type': 'text',
+                            'analyzer': analyzer,
+                            'search_analyzer': search_analyzer,
+                        },
                         'folded': {
                             'type': 'text',
                             'analyzer': 'folding'
@@ -198,9 +207,12 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                 },
                 'description': {
                     'type': 'text',
-                    'analyzer': analyzer,
-                    'search_analyzer': search_analyzer,
                     'fields': {
+                        'analyzed': {
+                            'type': 'text',
+                            'analyzer': analyzer,
+                            'search_analyzer': search_analyzer,
+                        },
                         'folded': {
                             'type': 'text',
                             'analyzer': 'folding'
@@ -208,10 +220,6 @@ def create_elastic_search_index_configuration(lang, analyzer, decompound_word_li
                     }
                 },
                 'url': {'type': 'text'},
-                'title_plain': {'type': 'text'},
-                'text_plain': {'type': 'text'},
-                'transcription_plain': {'type': 'text'},
-                'description_plain': {'type': 'text'},
                 'authors': {
                     'type': 'text',
                     'fields': {

--- a/harvester/core/models/datatypes/document.py
+++ b/harvester/core/models/datatypes/document.py
@@ -42,7 +42,6 @@ class Document(DocumentPostgres, DocumentBase):
             '_id': reference_id,
             'title': title,
             'url': url,
-            'title_plain': title,
             'file_type': file_type,
             'mime_type': mime_type,
             'has_parts': has_parts,
@@ -53,7 +52,6 @@ class Document(DocumentPostgres, DocumentBase):
         if text:
             details.update({
                 'text': text,
-                'text_plain': text,
                 'suggest_phrase': text
             })
         return details

--- a/harvester/core/tests/commands/test_index_dataset_version.py
+++ b/harvester/core/tests/commands/test_index_dataset_version.py
@@ -30,12 +30,12 @@ class ElasticSearchClientTestCase(TestCase):
         # Here we check if documents have all required keys including _id
         expected_keys = {
             "title", "url", "external_id", "disciplines", "lom_educational_levels", "description", "publisher_date",
-            "copyright", "language", "title_plain", "keywords", "file_type", "mime_type", "suggest_completion", "_id",
+            "copyright", "language", "keywords", "file_type", "mime_type", "suggest_completion", "_id",
             "oaipmh_set", "harvest_source",  "aggregation_level", "publishers", "authors", "has_parts", "has_part",
             "is_part_of", "preview_path", "analysis_allowed", "ideas", "copyright_description",
         }
         text_keys = {
-            "text", "text_plain", "suggest_phrase",
+            "text", "suggest_phrase",
         }
         if has_text:
             expected_keys.update(text_keys)

--- a/service/surf/vendor/elasticsearch/api.py
+++ b/service/surf/vendor/elasticsearch/api.py
@@ -227,9 +227,9 @@ class ElasticSearchApiClient:
             query_string = {
                 "simple_query_string": {
                     "fields": [
-                        "title^2", "title_plain^2", "title.folded^2",
-                        "text", "text_plain", "text.folded",
-                        "description", "description.folded",
+                        "title^2", "title.analyzed^2", "title.folded^2",
+                        "text", "text.analyzed", "text.folded",
+                        "description", "description.analyzed", "description.folded",
                         "keywords", "keywords.folded",
                         "authors", "authors.folded",
                         "publishers", "publishers.folded",

--- a/service/surf/vendor/search/tests/tests_elastic_search.py
+++ b/service/surf/vendor/search/tests/tests_elastic_search.py
@@ -399,13 +399,20 @@ class TestsElasticSearch(BaseElasticSearchTestCase):
             'updateable': True
         })
         for text_field in ["title", "text", "transcription", "description"]:
-            self.assertEqual(dutch_index["mappings"]["properties"][text_field]["analyzer"], "dutch")
-            self.assertEqual(dutch_index["mappings"]["properties"][text_field]["search_analyzer"],
+            self.assertEqual(dutch_index["mappings"]["properties"][text_field]['fields']['analyzed']["analyzer"],
+                             "dutch")
+            self.assertEqual(dutch_index["mappings"]["properties"][text_field]['fields']['analyzed']["search_analyzer"],
                              "dutch_dictionary_decompound")
 
         english_index = create_elastic_search_index_configuration("en", "english")
         self.assertNotIn("dutch_dictionary_decompound", english_index["settings"]["analysis"]["analyzer"])
         self.assertNotIn("dictionary_decompound", english_index["settings"]["analysis"]["filter"])
         for text_field in ["title", "text", "transcription", "description"]:
-            self.assertEqual(english_index["mappings"]["properties"][text_field]["analyzer"], "english")
-            self.assertEqual(english_index["mappings"]["properties"][text_field]["search_analyzer"], "english")
+            self.assertEqual(
+                english_index["mappings"]["properties"][text_field]['fields']['analyzed']["analyzer"],
+                "english"
+            )
+            self.assertEqual(
+                english_index["mappings"]["properties"][text_field]['fields']['analyzed']["search_analyzer"],
+                "english"
+            )


### PR DESCRIPTION
Removes characters, like accents. For example now searching for `efficient` also returns documents with the word `efficiënt`.

Instead of using a plain field I created two subfields, the analyzed field and the folded field. The analyzed contains the dutch or english language analyzer and the folded field stripped the special characters out of it.

I introduced an extra field, because otherwise you can't search the other way around anymore. See: https://www.elastic.co/guide/en/elasticsearch/guide/current/asciifolding-token-filter.html