### PR TITLE
Fako/preview improvements

### DIFF
--- a/harvester/core/management/commands/generate_previews.py
+++ b/harvester/core/management/commands/generate_previews.py
@@ -23,10 +23,15 @@ class Command(PipelineCommand):
 
         youtube_documents = Document.objects.filter(
             dataset_version=dataset_version,
-            properties__from_youtube=True,
-            properties__analysis_allowed=True
+            properties__analysis_allowed=True,
+            properties__from_youtube=True
         )
-        youtube_processor = ShellPipelineProcessor({
+        vimeo_documents = Document.objects.filter(
+            dataset_version=dataset_version,
+            properties__analysis_allowed=True,
+            properties__url__startswith="https://vimeo.com"
+        )
+        youtube_dl_processor = ShellPipelineProcessor({
             "pipeline_app_label": "core",
             "pipeline_phase": "youtube_preview",
             "pipeline_depends_on": "metadata",
@@ -47,7 +52,8 @@ class Command(PipelineCommand):
                 }
             }
         })
-        results.append(youtube_processor(youtube_documents))
+        results.append(youtube_dl_processor(youtube_documents))
+        results.append(youtube_dl_processor(vimeo_documents))
 
         pdf_documents = Document.objects.filter(
             dataset_version=dataset_version,

--- a/harvester/core/models/resources/youtube_thumbnail.py
+++ b/harvester/core/models/resources/youtube_thumbnail.py
@@ -4,6 +4,7 @@ from io import BytesIO
 import requests
 from requests.status_codes import codes
 from urllib.parse import urlparse, urljoin
+from urlobject import URLObject
 
 from django.core.files import File
 from django.db import models
@@ -29,9 +30,13 @@ class YoutubeThumbnailResource(ShellResource):
 
     @staticmethod
     def get_preview_filename(thumbnail_url):
-        youtube_url = urlparse(thumbnail_url)
-        youtube_path = youtube_url.path
-        remainder, filename = os.path.split(youtube_path)
+        # Normalize source urls
+        if "vimeocdn" in thumbnail_url:
+            vimeo_url = URLObject(thumbnail_url)
+            thumbnail_url = vimeo_url.query_dict["src0"]
+        url = urlparse(thumbnail_url)
+        path = url.path
+        remainder, filename = os.path.split(path)
         name, ext = os.path.splitext(filename)
         remainder, youtube_id = os.path.split(remainder)
         return f"{youtube_id}{ext}"

--- a/harvester/core/models/resources/youtube_thumbnail.py
+++ b/harvester/core/models/resources/youtube_thumbnail.py
@@ -21,6 +21,7 @@ class YoutubeThumbnailResource(ShellResource):
 
     CMD_TEMPLATE = [
         "youtube-dl",
+        "--sleep-interval", "2",
         "--skip-download",
         "--get-thumbnail",
         "{}"

--- a/harvester/core/tests/commands/test_generate_previews.py
+++ b/harvester/core/tests/commands/test_generate_previews.py
@@ -59,9 +59,10 @@ class TestGeneratePreviews(TestCase):
                 }
             }
         )
-        self.assertEqual(shell_mock_result.call_count, 1)
+        self.assertEqual(shell_mock_result.call_count, 2)
         document_count_expectations = (
             Document.objects.filter(properties__from_youtube=True, properties__analysis_allowed=True).count(),
+            0  # No Vimeo Documents in the test set
         )
         for arguments, expectation in zip(shell_mock_result.call_args_list, document_count_expectations):
             args, kwargs = arguments


### PR DESCRIPTION
Processes Vimeo documents with YoutubeDL pipeline.
Sets a sleep interval to prevent rate limits from Youtube.